### PR TITLE
Create base class and decorators for simplifying writing OCS agents

### DIFF
--- a/example/simplified_agent.py
+++ b/example/simplified_agent.py
@@ -1,0 +1,54 @@
+from ocs import ocs_agent
+from ocs.agent import Agent, task, process_start, process_stop
+
+import time
+
+
+class MyHardwareDevice(Agent):
+
+    def __init__(self):
+        # Inherit __init__() from Agent, add any MyHardwareDevice specific
+        # attributes below here.
+        super(MyHardwareDevice, self).__init__()
+
+    # Task functions.
+    @task('squids')
+    def squids_task(self, session, params=None):
+        for step in range(5):
+            session.post_message('Tuning step %i' % step)
+            time.sleep(1)
+
+    @task('dets')
+    def dets_task(self, session, params=None):
+        for i in range(5):
+            session.post_message('Dets still tasking...')
+            time.sleep(1)
+
+    @process_start('acq')
+    def start_acq(self, session, params=None):
+        n_frames = 0
+        while True:
+            with self.lock:
+                print('Checking...', self.job)
+                if self.job == '!acq':
+                    break
+                elif self.job == 'acq':
+                    pass
+                else:
+                    return 10
+            n_frames += 100
+            time.sleep(.5)
+            session.post_message('Acquired %i frames...' % n_frames)
+
+    stop_acq = process_stop('acq')
+
+
+if __name__ == '__main__':
+    agent, runner = ocs_agent.init_ocs_agent('observatory.dets1')
+
+    my_hd = MyHardwareDevice()
+    agent.register_task('squids', my_hd.squids_task)
+    agent.register_task('dets', my_hd.dets_task)
+    agent.register_process('acq', my_hd.start_acq, my_hd.stop_acq)
+
+    runner.run(agent, auto_reconnect=True)

--- a/ocs/agent.py
+++ b/ocs/agent.py
@@ -1,0 +1,95 @@
+import threading
+
+
+class Agent:
+    """Generic OCS Agent.
+
+    To be inherited for writing one's own agents.
+    """
+    def __init__(self):
+        self.lock = threading.Semaphore()
+        self.job = None
+
+    # Exclusive access management.
+
+    def try_set_job(self, job_name):
+        with self.lock:
+            if self.job is None:
+                self.job = job_name
+                return True, 'ok.'
+            return False, 'Conflict: "%s" is already running.' % self.job
+
+    def set_job_done(self):
+        with self.lock:
+            self.job = None
+
+
+def task(name):
+    """Task decorator, apply to function to make an OCS Task.
+
+    Example:
+        @task('dets')
+        def dets_task(self, session, params=None)
+            for det in params[0]:
+                session.post_messag(f'Tuning det {det}')
+    """
+    def real_decorator(function):
+        def wrapper(self, session, params):
+            # preamble for decorator
+            ok, msg = self.try_set_job(name)
+            print('start %s:' % name, ok)
+            if not ok:
+                return ok, msg
+            session.post_status('running')
+
+            # function call in decorator
+            function(self, session, params)
+
+            # postamble
+            self.set_job_done()
+            return True, '%s task complete.' % name
+        return wrapper
+    return real_decorator
+
+
+def process_start(name):
+    """Process Start decorator, apply to function for starting a process."""
+    def real_decorator(function):
+        def wrapper(self, session, params):
+            # preamble for decorator
+            ok, msg = self.try_set_job(name)
+            print('start %s:' % name, ok)
+            if not ok:
+                return ok, msg
+            session.post_status('running')
+
+            # function call in decorator
+            function(self, session, params)
+
+            # postamble
+            self.set_job_done()
+            return True, '%s task complete.' % name
+        return wrapper
+    return real_decorator
+
+
+def process_stop(name):
+    """Process Stop function. Use as generic stop process.
+
+    :param name: name of process, must match that given to process_start
+    :type name: str
+
+    Example:
+        stop_acq = process_stop('acq')
+    """
+    def real_decorator(self, session, params=None):
+        ok = False
+        with self.lock:
+            if self.job == name:
+                self.job = f'!{name}'
+                ok = True
+
+        return (ok, {True: 'Requested process stop.',
+                     False: 'Failed to request process stop.'}[ok])
+
+    return real_decorator


### PR DESCRIPTION
While writing some (yet to be pushed) documentation on writing one's own OCS agents, and prior to writing an Agent for LS372 control, I noticed there's a lot of boilerplate that's going to get repeated a bunch. I've tried to simplify this by removing most of said boilerplate.

The main change here is the addition of `ocs/agent.py`, which defines the Agent class, as well as a working example in `example/simplified_agent.py`. `simplified_agent.py` performs the same functions as `example_agent.py`. The differences are:

- The threading bits in `__init__` and the `set_job` methods are inherited from this class.
- There are two new decorators defined, `task` and `process_start`, each takes an argument for the name of the task/process and should be applied to the methods which are written to perform a task/process.
  - For tasks this totally eliminates the boilerplate code of starting a job and setting the job as done. 
  - For processes, the thread locking bit still needs to be put in the while loop you write to keep the process going.
  - I think this also benefits the reader of an agent in labeling tasks in processes in an easy to read way
- Instead of a decorator for stopping a process I've simply used a sort of generic function which performs the actions needed to stop a process. This assumes you don't ever want to do anything else when stopping. I would have used a decorator here too, but I couldn't get one to actually work...

One point to bring up is that these two new decorators set the session status to 'running' in both cases, never actually making use of 'starting'. It's not entirely clear to me what 'starting' is used for, so if there is an important distinction this should be addressed before being merged.

In writing this Pull Request I realized since I couldn't get the `process_stop` decorator to work the `process_start` decorator probably could be renamed to be simply `process`. Feedback on things like this are certainly welcome.