### PR TITLE
Make docs compile without errors, out of the box.

### DIFF
--- a/agents/aggregator/aggregator_agent.py
+++ b/agents/aggregator/aggregator_agent.py
@@ -2,7 +2,9 @@ import time, threading
 import numpy as np
 from ocs import ocs_agent, site_config, client_t
 import os
-from spt3g import core
+if os.getenv('OCS_DOC_BUILD') != 'True':
+    from spt3g import core
+
 # import op_model as opm
 from autobahn.wamp.exception import ApplicationError
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,4 +17,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@OCS_DOC_BUILD=True $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/aggregator.rst
+++ b/docs/aggregator.rst
@@ -82,7 +82,7 @@ The aggregator will then write a G3Timestream for each thermometer on the 240.
 
 
 .. autoclass:: agents.aggregator.aggregator_agent.DataAggregator
-    :members: initialize, start_aggregate, subscribe_to_feed
+    :members: initialize, start_aggregate, add_feed_task
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,10 +12,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
-
+import os
+import sys
+sys.path.append(os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 
@@ -77,7 +76,7 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'bizstyle'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -88,7 +87,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
Imagining that we will one day want to compile the docs on ReadTheDocs, it must be possible to import ocs and all the agents, for the purposes of auto-documentation, without needing to install working versions of all our weird home-grown libraries.

For now we can solve this, as shown in aggregator_agent.py, by testing for the OCS_DOC_BUILD env variable.  We can do trickier things later, if need be.