### PR TITLE
Agents register onJoin and registry address come from site-config

### DIFF
--- a/agents/registry/registry.py
+++ b/agents/registry/registry.py
@@ -16,7 +16,6 @@ class Registry:
         self.active_agents = {}
         self.agent_timeout = 5.0 # Removes agent after 5 seconds of no heartbeat.
 
-
         self.agent.register_feed("agent_activity")
 
     def _monitor_active_agents(self):
@@ -27,6 +26,12 @@ class Registry:
         current_time = time.time()
         agents_to_remove = []
         for address, agent in self.active_agents.items():
+
+            # For some reason the registry has been unable to listen to its
+            # own heartbeat... This makes it so that the registry can't
+            # unregister itself.
+            if address == self.agent.agent_address:
+                continue
             if (current_time - agent["last_heartbeat"]) > self.agent_timeout:
                 agents_to_remove.append(address)
 
@@ -54,6 +59,7 @@ class Registry:
         """
 
         address = agent_data['agent_address']
+
         action = "added"
         if address in self.active_agents.keys():
             self.log.error("Address {} is already registered, agent info is being updated".format(address))

--- a/agents/thermometry/LS240_agent.py
+++ b/agents/thermometry/LS240_agent.py
@@ -46,15 +46,6 @@ class LS240_Agent:
 
         session.set_status('starting')
 
-        # Registers agent
-        try:
-            register_t = client_t.TaskClient(session.app, 'observatory.registry', 'register_agent')
-            session.call_operation(register_t.start, self.agent.encoded(), block=True)
-            self.registered = True
-        except ApplicationError as e:
-            if e.error == u'wamp.error.no_such_procedure':
-                self.log.error("Registry is not running")
-
         if self.fake_data:
             session.add_message("No initialization since faking data")
             self.thermometers = ["thermA", "thermB"]

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -166,6 +166,7 @@ def add_arguments(parser=None):
     group.add_argument('--site-realm')
     group.add_argument('--instance-id')
     group.add_argument('--address-root')
+    group.add_argument('--registry-address')
     return parser
     
 def get_config(args, agent_class=None):
@@ -208,6 +209,9 @@ def get_config(args, agent_class=None):
     # Override the realm?
     if args.site_realm is not None:
         site_config.hub.data['wamp_realm'] = args.site_realm
+
+    if args.registry_address is not None:
+        site_config.hub.data['registry_address'] = args.registry_address
 
     # Matching behavior.
     no_dev_match = (agent_class == '*control*')
@@ -274,6 +278,8 @@ def reparse_args(args, agent_class=None):
         args.site_realm = site.hub.data['wamp_realm']
     if args.address_root is None:
         args.address_root = site.hub.data['address_root']
+    if args.registry_address is None:
+        args.registry_address = site.hub.data.get('registry_address')
 
     if instance is not None:
         if args.instance_id is None:


### PR DESCRIPTION
This commit adds a `register_agent` function to OCSAgent, and automatically registers the agent onJoin if possible. It also gets the registry address from the site-config instead of having it hardcoded in. I'm not 100% sure I added it into the site-config correctly, so Matthew it might be good if you could go review what I changed in `site_config.py`. The only thing is that now we need to add the registry address to the yaml config file, so it looks something like this:

```
hub:

  wamp_server: ws://localhost:8001/ws
  wamp_realm: debug_realm
  address_root: observatory
  registry_address: observatory.registry
```

Is this ok? Or should I change the site_config code so that it defaults to 'observatory.registry' if its not found in the config file? Can we push this change for the config file to test institutions through the ocs-site-configs repo? Thanks!

