### PR TITLE
Fix examples to work with example site-config file

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -21,7 +21,7 @@ run_crossbar:
 	$(CROSSBAR) start --cbdir dot_crossbar/
 
 run_agent:
-	$(PYTHON) example_agent.py
+	$(PYTHON) example_agent.py --site-file example-site-config.yaml --site-host 'example'
 
 run_client:
 	$(PYTHON) example_ctrl.py

--- a/example/example-site-config.yaml
+++ b/example/example-site-config.yaml
@@ -1,0 +1,22 @@
+# Site configuration for a fake observatory.
+hub:
+
+  wamp_server: ws://localhost:8001/ws
+  wamp_realm: test_realm
+  address_root: observatory
+  registry_address: observatory.registry
+
+hosts:
+
+  example: {
+
+    # Description of grumpy's Agents.  We have two readout devices;
+    # they are both Lakeshore 372s.  But they can be distinguished, on
+    # startup, by a device serial number.
+
+    'agent-instances': [
+      {'agent-class': 'ExampleAgent',
+       'instance-id': 'example1',
+       'arguments': [['--serial-number', 'EX123']]},
+    ]
+  }

--- a/example/example_agent.py
+++ b/example/example_agent.py
@@ -1,4 +1,4 @@
-from ocs import ocs_agent
+from ocs import ocs_agent, site_config
 #import op_model as opm
 
 import time, threading
@@ -86,7 +86,23 @@ class MyHardwareDevice:
 
 
 if __name__ == '__main__':
-    agent, runner = ocs_agent.init_ocs_agent('observatory.dets1')
+    # Get an ArgumentParser
+    parser = site_config.add_arguments()
+
+    # Add arguments that are specific to this Agent's function.
+    pgroup = parser.add_argument_group('Agent Options')
+    pgroup.add_argument('--serial-number')
+
+    # Get the parser to process the command line.
+    args = parser.parse_args()
+
+    # Interpret options in the context of site_config.
+    site_config.reparse_args(args, 'ExampleAgent')
+    print('I am in charge of device with serial number: %s' % args.serial_number)
+
+    # Call launcher function (initiates connection to appropriate
+    # WAMP hub and realm).
+    agent, runner = ocs_agent.init_site_agent(args)
 
     my_hd = MyHardwareDevice()
     agent.register_task('squids', my_hd.squids_task) 

--- a/example/example_ctrl.py
+++ b/example/example_ctrl.py
@@ -88,5 +88,5 @@ def my_script(app, agent_addr):
     print(x)
 
 if __name__ == '__main__':
-    client_t.run_control_script(my_script, u'observatory.dets1')
+    client_t.run_control_script(my_script, u'observatory.example1')
     

--- a/example/example_ctrl_sync.py
+++ b/example/example_ctrl_sync.py
@@ -11,8 +11,9 @@ import time
 
 addr = 'ws://localhost:8001/ws'
 agent = 'observatory.dets1'
+realm = 'test_realm'
 
-with ControlClient(agent, url=addr) as client:
+with ControlClient(agent, url=addr, realm=realm) as client:
     print(client.call(agent, 'get_tasks'))
     # Request a task to start.
     print('I will request to start a task...')
@@ -27,7 +28,7 @@ with ControlClient(agent, url=addr) as client:
     print()
 
 # You don't have to use a context manager.
-client = ControlClient(agent_addr=agent, url=addr)
+client = ControlClient(agent_addr=agent, url=addr, realm=realm)
 client.start()
     
 while True:

--- a/example/nonblocking_ops/Makefile
+++ b/example/nonblocking_ops/Makefile
@@ -21,7 +21,7 @@ run_crossbar:
 	$(CROSSBAR) start --cbdir ../dot_crossbar/
 
 run_agent:
-	$(PYTHON) example_agent.py
+	$(PYTHON) example_agent.py --site-file ../example-site-config.yaml --site-host 'example'
 
 run_client:
 	$(PYTHON) example_ctrl.py

--- a/example/nonblocking_ops/example_agent.py
+++ b/example/nonblocking_ops/example_agent.py
@@ -1,4 +1,4 @@
-from ocs import ocs_agent
+from ocs import ocs_agent, site_config
 import time
 
 from twisted.internet.defer import inlineCallbacks
@@ -78,7 +78,23 @@ class MyHardwareDevice:
 
 
 if __name__ == '__main__':
-    agent, runner = ocs_agent.init_ocs_agent('observatory.example1')
+    # Get an ArgumentParser
+    parser = site_config.add_arguments()
+
+    # Add arguments that are specific to this Agent's function.
+    pgroup = parser.add_argument_group('Agent Options')
+    pgroup.add_argument('--serial-number')
+
+    # Get the parser to process the command line.
+    args = parser.parse_args()
+
+    # Interpret options in the context of site_config.
+    site_config.reparse_args(args, 'ExampleAgent')
+    print('I am in charge of device with serial number: %s' % args.serial_number)
+
+    # Call launcher function (initiates connection to appropriate
+    # WAMP hub and realm).
+    agent, runner = ocs_agent.init_site_agent(args)
 
     my_hd = MyHardwareDevice()
     agent.register_task('task1', my_hd.task1)

--- a/example/ocs.cfg
+++ b/example/ocs.cfg
@@ -1,4 +1,0 @@
-[default]
-wamp_server = ws://localhost:8001/ws
-wamp_realm = test_realm
-


### PR DESCRIPTION
Added an example site-config file and adjusted the Makefiles accordingly in the base example and the nonblockingops examples. Other examples, like the one in `concepts/` and `site_config/` were working. `site_config` and the base example are now extremely similar, the main difference being that the `site_config` example has a different crossbar configuration that uses a `debug_realm`.

Fixes #26.

@ahincks See if this works for you. If things go smoothly, I'll merge into master. Suggestions/comments definitely welcome as you try to get it working.