### PR TITLE
ocsbow: control over crossbar server.

### DIFF
--- a/bin/ocsbow
+++ b/bin/ocsbow
@@ -9,6 +9,7 @@ try:
 except ImportError:
     pass
 
+import os
 import sys
 import time
 
@@ -23,34 +24,99 @@ args = parser.parse_args()
 ocs.site_config.reparse_args(args, '*host*')
 
 if args.command == 'config':
-    print('ocs configuration summary')
-    print('-------------------------')
-    print()
-    print('ocs import led to: %s' % (ocs.__file__))
-    print()
-    site, _, _ = ocs.site_config.get_config(args, '*host*')
-    print('Site file was determined to be: %s' % site.source_file)
-    print()
-    print('The site file describes %i hosts:' % len(site.hosts))
-    for k,v in site.hosts.items():
-        print('  Host %s includes %i agent instances:' % (k, len(v.instances)))
-        for inst in v.instances:
-            print('    %s::%s' % (inst['agent-class'], inst['instance-id']))
+
+    if args.cfg_request == 'summary':
+        print('ocs configuration summary')
+        print('-------------------------')
+        print()
+        print('ocs import led to: %s' % (ocs.__file__))
+        print()
+        site, _, _ = ocs.site_config.get_config(args, '*host*')
+        print('Site file was determined to be: %s' % site.source_file)
+        print()
+        print('The site file describes %i hosts:' % len(site.hosts))
+        for k,v in site.hosts.items():
+            print('  Host %s includes %i agent instances:' % (k, len(v.instances)))
+            for inst in v.instances:
+                print('    %s::%s' % (inst['agent-class'], inst['instance-id']))
+            print()
+
+    if args.cfg_request == 'plugins':
+        print('ocs plugin detection')
+        print('--------------------')
+        print('Scanning.')
+        site, host, _  = ocs.site_config.get_config(args, '*host*')
+        for p in host.agent_paths:
+            print('  ... adding to path: %s' % p)
+            sys.path.append(p)
+        ocs.site_config.scan_for_agents()
+        print('Found:')
+        for k,v in ocs.site_config.agent_script_reg.items():
+            print('  %-20s : %s' % (k,v))
         print()
 
-if args.command == 'plugins':
-    print('ocs plugin detection')
-    print('--------------------')
-    print('Scanning.')
-    site, host, _  = ocs.site_config.get_config(args, '*host*')
-    for p in host.agent_paths:
-        print('  ... adding to path: %s' % p)
-        sys.path.append(p)
-    ocs.site_config.scan_for_agents()
-    print('Found:')
-    for k,v in ocs.site_config.agent_script_reg.items():
-        print('  %-20s : %s' % (k,v))
-    print()
+    if args.cfg_request == 'crossbar':
+        print('ocs crossbar configuration')
+        print('--------------------------')
+        print()
+        site, host, _  = ocs.site_config.get_config(args, '*host*')
+        print('Configuration for the OCS hub:')
+        print(site.hub.summary())
+        print()
+        print('Configuration for crossbar service on this host (%s):' % host.name)
+        if host.crossbar is None:
+            print('  Not configured.')
+        else:
+            print(host.crossbar.summary())
+        print()
+
+elif args.command in ['crossbar']:
+    site, host, instance = ocs.site_config.get_config(args, '*host*')
+
+    if args.cb_request == 'generate_config':
+        import urllib
+        urld = urllib.parse.urlparse(site.hub.data['wamp_server'])
+        pars = {
+            'realm': site.hub.data['wamp_realm'],
+            'address_root': site.hub.data['address_root'],
+            'port': urld.port,
+        }
+        print('Writing crossbar config to stdout...', file=sys.stderr)
+        print(ocsbow.render_crossbar_config_example(pars))
+        text = '\n'
+        if host.crossbar is None:
+            text += 'There is no crossbar entry in this host config.\n\n'
+        else:
+            if host.crossbar.cbdir is None:
+                text += 'The crossbar config-dir is not set in this host config.\n\n'
+            else:
+                text += ('The crossbar config-dir is set to "%s";\nthe config '
+                         'text should be copied to the file config.json in '
+                         'that directory.\n' % host.crossbar.cbdir)
+        print(text, file=sys.stderr)
+    else:
+        # Start / stop / check the crossbar server.
+        cmd = host.crossbar.get_cmd(args.cb_request)
+        flags = os.P_WAIT
+        monitor_time = None
+        if args.cb_request == 'start' and not args.fg:
+            # By default, we launch to background.  We leave error logging
+            # on, becausee start-up issues (such as trying to start when
+            # another session is already active) will otherwise be
+            # annoying to diagnose.
+            cmd.extend(['--loglevel', 'error'])
+            flags = os.P_NOWAIT
+            monitor_time = 2.
+        print('Executing: ', cmd)
+        pid = os.spawnv(flags, cmd[0], cmd)
+        if monitor_time is not None:
+            time.sleep(monitor_time)
+            try:
+                os.kill(pid, 0)
+                print('New crossbar instance running as pid %i' % pid)
+            except OSError:
+                print('New crossbar instance exited within %.1f seconds.' % monitor_time)
+                sys.exit(10)
 
 elif args.command in ['launch']:
     # This is specifically for starting the host master agent process;
@@ -61,7 +127,6 @@ elif args.command in ['launch']:
     site, host, instance = ocs.site_config.get_config(args, 'HostMaster')
 
     # Most important is the site filename and host alias.
-    import os
     hm_script = os.path.join(host.agent_paths[0], 'host_master/host_master.py')
     cmd = [sys.executable, hm_script,
            '--site-file', site.source_file,

--- a/docs/site_config.rst
+++ b/docs/site_config.rst
@@ -92,6 +92,9 @@ instances (running two different classes of agent):
   
     host-2: {
   
+      # Crossbar start-up instructions (optional).
+      'crossbar': {'config-dir': /sobs/ocs/dot_crossbar/'},
+
       # List of additional paths to Agent plugin modules.
       'agent-paths': [
         '/sobs/ocs/agents/',
@@ -130,16 +133,11 @@ the SiteConfig class:
 .. autoclass:: ocs.site_config.SiteConfig
    :members: from_dict
 
-The difference between a host name and a "pseudo-host name" is that a
-host name might plausibly be computed automatically by calling
-``socket.gethostname``, while a pseudo-host name is something the user
-will have to specify explicitly (perhaps through the command line
-argument ``--site-host``) when invoking the agent.
-
-The ``hub`` information is used by all Agent and Control Clients to
-connect to the OCS WAMP router.  This WAMP router (probably crossbar)
-usually has its own configuration file.  The settings in SCF ``hub``
-block are parsed by the ``from_dict`` method of the HubConfig class:
+The ``hub`` information is used by all Agent and Control Clients, on
+all hosts, to connect to the OCS WAMP router.  This WAMP router
+(probably crossbar) usually has its own configuration file.  The
+settings in SCF ``hub`` block are parsed by the ``from_dict`` method
+of the HubConfig class:
 
 .. autoclass:: ocs.site_config.HubConfig
    :members: from_dict
@@ -153,7 +151,17 @@ method of the HostConfig class:
 .. autoclass:: ocs.site_config.HostConfig
    :members: from_dict
 
-The significance of ``agent-paths`` is described more in :ref:`agent_plugins`.
+To allow ocs to manipulate the ``crossbar`` router (e.g. if you want
+to easily start and stop it using ``ocsbow``), then the ``crossbar``
+variable should be defined, with (at least) an empty dictionary.  The
+details of the options are described in the ``from_dict`` method of
+the CrossbarConfig class:
+
+.. autoclass:: ocs.site_config.CrossbarConfig
+   :members: from_dict
+
+The significance of ``agent-paths`` is described more in
+:ref:`agent_plugins`.
 
 InstanceConfig
 --------------

--- a/ocs/ocsbow.py
+++ b/ocs/ocsbow.py
@@ -5,10 +5,10 @@ to assist with autodoc in sphinx.
 
 """
 
-
 import ocs
 
 import argparse
+import os
 
 DESCRIPTION="""This is the high level control script for ocs.  Its principal uses
 are to inspect the local host's site configuration file, and to start
@@ -17,9 +17,67 @@ and communicate with the HostMaster Agent for the local host."""
 def get_parser():
     parser = argparse.ArgumentParser(description=DESCRIPTION)
     parser = ocs.site_config.add_arguments(parser)
-    parser.add_argument('command', choices=['config', 'plugins', 'status',
-                                            'monitor',
-                                            'launch',
-                                            'start', 'stop'])
     parser.add_argument('--follow', '-f', action='store_true')
+    cmdsubp = parser.add_subparsers(dest='command')
+
+    # config
+    p = cmdsubp.add_parser('config', help=
+                           'Query the local OCS config.')
+    p.add_argument('cfg_request', nargs='?', choices=['summary', 'plugins', 'crossbar'],
+                   default='summary')
+
+    # crossbar
+    p = cmdsubp.add_parser('crossbar', help=
+                           'Manipulate the local crossbar router.')
+    p.add_argument('cb_request', choices=['start', 'stop', 'status',
+                                          'generate_config'], help=
+                   'Use these commands to start, stop, or request status '
+                   'from the local crossbar server, if such configuration '
+                   'is described in the host config.  The generate_config '
+                   'sub-command can be used to produce a crossbar JSON '
+                   'configuration file consistent with the parameters in '
+                   'the host config.')
+    p.add_argument('--fg', action='store_true', default=False,
+                   help='If request is "start", run in foreground rather '
+                   'than spawning to background.')
+
+    # hostmaster agent instance
+    p = cmdsubp.add_parser('launch', help=
+                           'Launch an instance of the HostMaster agent.')
+
+    p = cmdsubp.add_parser('monitor', help=
+                           'Connect to the HostMaster log feed and copy to '
+                           'the terminal.')
+
+    # start, stop
+    p = cmdsubp.add_parser('start', help=
+                           'Start the HostMaster agent.')
+    p = cmdsubp.add_parser('stop', help=
+                           'Stop the HostMaster agent.')
+    p = cmdsubp.add_parser('status', help=
+                           'Show status of the HostMaster agent.')
+    
     return parser
+
+def render_crossbar_config_example(pars):
+    """Returns the text of a basic crossbar config file, suitable for OCS
+    use.
+    
+    """
+    _pars = {
+        'realm': 'debug_realm',
+        'address_root': 'observatory',
+        'port': 8001,
+    }
+    _pars.update(pars)
+    
+    # Generate configuration file.
+    template_file = os.path.join(os.path.split(ocs.__file__)[0],
+                                 'support/crossbar_config.json')
+    config_text = open(template_file).read()
+
+    # Manual substitution, since json contains many { formatting chars }.
+    for k, v in _pars.items():
+        config_text = config_text.replace('{'+k+'}', str(v))
+
+    return config_text

--- a/ocs/support/crossbar_config.json
+++ b/ocs/support/crossbar_config.json
@@ -1,0 +1,75 @@
+{
+    "version": 2,
+    "workers": [
+        {
+            "type": "router",
+            "options": {
+                "pythonpath": [
+                    ".."
+                ]
+            },
+            "realms": [
+                {
+                    "name": "{realm}",
+                    "roles": [
+                        {
+                            "name": "iocs_agent",
+                            "permissions": [
+                                {
+                                    "uri": "{address_root}.",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
+                        },
+                        {
+                            "name": "iocs_controller",
+                            "permissions": [
+                                {
+                                    "uri": "{address_root}.",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": false,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "transports": [
+                {
+                    "type": "websocket",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": {port}
+                    },
+                    "auth": {
+                        "anonymous": {
+                            "type": "static",
+                            "role": "iocs_agent"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,6 @@ setup (name = 'ocs',
        package_dir={'ocs': 'ocs'},
        packages=['ocs', 'ocs/Lakeshore', 'ocs/util'],
        scripts=['bin/ocsbow'],
+       package_data={'': ['support/*json']}, 
        version=versioneer.get_version(),
        cmdclass=versioneer.get_cmdclass())


### PR DESCRIPTION
- site_config host descriptions may contain a 'crossbar' entry that
  describes how to launch a crossbar router.
- Good crossbar start/stop/status support from the ocsbow cli.
- A basic crossbar config.json file can be generated, using ocsbow,
  based on the site_config file parameters.
- site_config will match any host to "localhost" config in the
  site_config file, if there is no direct match to hostname.