### PR TITLE
Create Dockerfile and add build to Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# ocs-docker
+# A container setup with an installation of ocs.
+
+# Use ubuntu base image
+FROM ubuntu:18.04
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Install python and pip
+RUN apt-get update && apt-get install -y python3 \
+    python3-pip
+
+# Copy the current directory contents into the container at /app
+COPY . /app/
+
+# Install ocs
+RUN pip3 install -r requirements.txt .

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ include Makefile.local
 endif
 
 PYTHON ?= python
+VERSION := $(shell python -c 'import ocs; print (ocs.__version__)')
 
 ifneq ($(PREFIX),)
 install_args = --prefix=$(PREFIX)
@@ -20,5 +21,10 @@ develop:
 bundle:
 	git archive HEAD --format=tar --prefix=ocs/ | gzip -c > ocs.tar.gz
 
+docker-image:
+	docker build -t ocs:$(VERSION) .
+	docker tag ocs:$(VERSION) ocs:latest
 
 .dummy: default install
+
+# vim: set expandtab!:

--- a/ocs/_version.py
+++ b/ocs/_version.py
@@ -40,7 +40,7 @@ def get_config():
     # _version.py
     cfg = VersioneerConfig()
     cfg.VCS = "git"
-    cfg.style = "pep440"
+    cfg.style = "git-describe"
     cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "ocs-"
     cfg.versionfile_source = "ocs/_version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [versioneer]
 VCS = git
-style = pep440
+style = git-describe
 versionfile_source = ocs/_version.py
 versionfile_build = ocs/_version.py
 tag_prefix = v


### PR DESCRIPTION
This commit creates a `Dockerfile` to build an Ubuntu based container with ocs installed on it.

I've also added `make docker-image` to the `Makefile`. Coupled with this is a small change to the [configuration of versioneer](https://github.com/warner/python-versioneer/blob/master/details.md#how-do-i-select-a-version-style), allowing the version number to be used in the `Makefile` to tag the built Docker image. This ensures the version used to build the image is associated with the image itself. I've selected the "git-describe" style, which contains the same information that the "pep440" style did, but does not use a "+", which is not a valid character for use in a Docker tag.

While we could put the `Dockerfile` in its own repo, possibly with many other Dockerfiles, I think this makes the most sense, since the first step otherwise is "obtain a copy of the ocs repo".
