### PR TITLE
Clean up the README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,8 @@ Overview
 
 The OCS makes it easy to coordinate hardware operation and I/O tasks in a
 distributed system such as an astronomical observatory or test laboratory. OCS
-relies on the use of a central WAMP router (currently `crossbar.io
-<http://crossbario.com>`_) for coordinating the communication and control of these
-distributed systems.
+relies on the use of a central WAMP router (currently `crossbar.io`_) for
+coordinating the communication and control of these distributed systems.
 
 The OCS provides Python (and JavaScript) functions and classes to allow
 "Clients" to talk to "Agents". An Agent is a software program that knows how to
@@ -17,6 +16,8 @@ do something interesting and useful, such as acquire data from some device or
 perform cleanup operations on a particular file system. A Control Client could
 be a web page with control buttons and log windows, or a script written by a
 user to perform a series of unattended, interlocking data acquisition tasks.
+
+.. _crossbar.io: http://crossbario.com
 
 Dependencies
 ------------
@@ -36,11 +37,11 @@ Clone this repository and install using pip::
   pip3 install -r requirements.txt
   python3 setup.py install
 
-**Note:** If you want to install locally, not globally, throw the `--user` flag on
-both the pip3 and setup.py commands.
+**Note:** If you want to install locally, not globally, throw the `--user` flag
+on both the pip3 and setup.py commands.
 
-**Warning:** The master branch is not guaranteed to be stable, you might want to
-checkout a particular version tag before installation depending on which
+**Warning:** The master branch is not guaranteed to be stable, you might want
+to checkout a particular version tag before installation depending on which
 other software you are working with. See the latest `tags`_.
 
 .. _tags: https://github.com/simonsobs/ocs/tags
@@ -69,6 +70,7 @@ in that directory for details.
 
 License
 --------
-This project is licensed under the BSD 2-Clause License - see the `LICENSE.txt`_ file for details.
+This project is licensed under the BSD 2-Clause License - see the
+`LICENSE.txt`_ file for details.
 
 .. _LICENSE.txt: LICENSE.txt


### PR DESCRIPTION
Simplify the README by moving much of the descriptive details to the Sphinx
documentation, eliminating non-working examples that were present, and adding
links to working examples as well as the license.

Since pip has been segfaulting on some systems, we now recommend installing the
dependencies with pip and installing OCS by running setup.py directly.

The goal here is to tell people how to get the software, how to read more detailed documentation, and point to an example which can be kept up to date.