### PR TITLE
ocsbow launches host_master.py with --quiet option.

### DIFF
--- a/agents/host_master/host_master.py
+++ b/agents/host_master/host_master.py
@@ -414,8 +414,16 @@ if __name__ == '__main__':
     pgroup = parser.add_argument_group('Agent Options')
     pgroup.add_argument('--initial-state', default='down',
                         choices=['up', 'down'])
+    pgroup.add_argument('--quiet', action='store_true')
     args = parser.parse_args()
     site_config.reparse_args(args, 'HostMaster')
+
+    if args.quiet:
+        # For launch-to-background, disconnect stdio.
+        null = os.open(os.devnull, os.O_RDWR)
+        for stream in [sys.stdin, sys.stdout, sys.stderr]:
+            os.dup2(null, stream.fileno())
+        os.close(null)
 
     # To reduce "try again" noise, don't tell Registry about HostMaster.
     args.registry_address = 'none'

--- a/ocs/ocsbow.py
+++ b/ocs/ocsbow.py
@@ -367,6 +367,7 @@ class HostMasterManager:
         print('Launching HostMaster through %s' % hm_script)
         print('Log dir is: %s' % log_dir)
         cmd = [sys.executable, hm_script,
+               '--quiet',
                '--site-file', site.source_file,
                '--site-host', host.name,
                '--working-dir', self.working_dir]


### PR DESCRIPTION
This prevents spamming the user's ocsbow terminal.  User must monitor
the host_master log for useful information.