### PR TITLE
Fix agg prov_id sync issue

### DIFF
--- a/agents/aggregator/Dockerfile
+++ b/agents/aggregator/Dockerfile
@@ -11,6 +11,9 @@ WORKDIR /app/agents/aggregator/
 RUN mkdir -p /data && \
     chown ocs:ocs /data
 
+# Copy this local copy into place over the OCS base image
+COPY aggregator_agent.py /app/agents/aggregator/
+
 # Run registry on container startup
 ENTRYPOINT ["python3", "-u", "aggregator_agent.py"]
 

--- a/agents/aggregator/aggregator_agent.py
+++ b/agents/aggregator/aggregator_agent.py
@@ -427,8 +427,11 @@ class DataAggregator:
                               .format(prov.address, prov.agent_id))
                 pid = prov.prov_id
                 self.hksess.remove_provider(pid)
-                del self.prov_ids[prov.address]
                 del self.providers[pid]
+
+                if self.prov_ids[prov.address] == pid:
+                    del self.prov_ids[prov.address]
+
 
             # Then write status if we need to
             if self.should_write_status:

--- a/agents/aggregator/aggregator_agent.py
+++ b/agents/aggregator/aggregator_agent.py
@@ -198,15 +198,7 @@ class DataAggregator:
             else:
                 prov = None
 
-            # # Assumes agent ids are ordered
-            # if prov is not None:
-            #     if prov.agent_id < agent_id:
-            #         # If somehow its an old version of the feed, remove it
-            #         self.log.warn("Somehow there is a new instance of {}."
-            #                       "Scheduling removal of old instance".format(feed['address']))
-            #         prov.remove = True
-
-            if action == 'removed':
+            if action == 'removed' and prov is not None:
                 self.log.info("Scheduled remove for provider {} ({})"
                               .format(feed['address'], agent_id))
                 prov.remove = True

--- a/agents/aggregator/aggregator_agent.py
+++ b/agents/aggregator/aggregator_agent.py
@@ -21,7 +21,7 @@ class Provider:
     Attributes:
         addresss (string):
             Full address of the Provider feed
-        agent_id (string):
+        session_id (string):
             session_id of agent who owns the Feed
         frame_length (float):
             Time before data should be written into a frame
@@ -37,7 +37,7 @@ class Provider:
         self.prov_id = prov_id
 
         self.address = feed['address']
-        self.agent_id = feed['agent_session_id']
+        self.session_id = feed['session_id']
         self.frame_length = feed['agg_params']['frame_length']
 
         self.lock = RLock()
@@ -98,7 +98,7 @@ class Provider:
             frame = core.G3Frame(core.G3FrameType.Housekeeping)
 
         frame['address'] = self.address
-        frame['agent_session_id'] = self.agent_id
+        frame['session_id'] = self.session_id
 
         for block_name, block in self.blocks.items():
             if not block.timestamps:
@@ -165,7 +165,7 @@ class DataAggregator:
             return
 
         data, feed = _data
-        prov_id = self.prov_ids[(feed["address"], feed["agent_session_id"])]
+        prov_id = self.prov_ids[(feed["address"], feed["session_id"])]
         prov = self.providers[prov_id]
 
         prov.lock.acquire()
@@ -183,16 +183,16 @@ class DataAggregator:
 
         (action, agent_data), feed_data = _data
         agent_address = agent_data['agent_address']
-        agent_id = agent_data['agent_session_id']
+        session_id = agent_data['session_id']
 
-        self.log.debug("Agent activity --- Agent: {}, sess: {}, action: {}"
-                      .format(agent_address, agent_id, action))
+        self.log.debug("Agent activity --- Agent: {}, session_id: {}, action: {}"
+                      .format(agent_address, session_id, action))
 
         for feed in agent_data['feeds']:
             if not feed['record']:
                 continue
 
-            pid = self.prov_ids.get((feed["address"], agent_id))
+            pid = self.prov_ids.get((feed["address"], session_id))
             if pid is not None:
                 prov = self.providers[pid]
             else:
@@ -200,21 +200,21 @@ class DataAggregator:
 
             if action == 'removed' and prov is not None:
                 self.log.info("Scheduled remove for provider {} ({})"
-                              .format(feed['address'], agent_id))
+                              .format(feed['address'], session_id))
                 prov.remove = True
 
             if action in ['added', 'status']:
                 if prov is not None:
-                    self.log.warn("Provider {} ({}) already exists.".format(feed['address'], agent_id))
+                    self.log.warn("Provider {} ({}) already exists.".format(feed['address'], session_id))
                     return
 
                 prov_id = self.hksess.add_provider(
                     description="{}".format(feed['address'])
                 )
                 self.providers[prov_id] = Provider(feed, prov_id)
-                self.prov_ids[(feed["address"], agent_id)] = prov_id
+                self.prov_ids[(feed["address"], session_id)] = prov_id
                 self.log.info("Added provider {} (agent sess: {}) with id {}"
-                              .format(feed['address'], agent_id, prov_id))
+                              .format(feed['address'], session_id, prov_id))
                 self.should_write_status = True
                 self.agent.subscribe_to_feed(agent_address,
                                              feed['feed_name'],
@@ -236,7 +236,7 @@ class DataAggregator:
         )
 
         x = {
-            'agent_session_id': -1,
+            'session_id': -1,
             'address': params['address'],
             'frame_length': params['frame_length'],
         }
@@ -387,12 +387,14 @@ class DataAggregator:
                 ts = datetime.utcnow().timestamp()
 
             # Removes old providers if new ones exist
-            keys = sorted(self.prov_ids, key=lambda x:x[1], reverse=True)
+            keys = sorted(self.prov_ids, key=lambda x: x[1], reverse=True)
             feeds = []
             for k in keys:
                 if k[0] in feeds:
-                    print("Newer {} feed found".format(k[0]))
-                    self.providers[self.prov_ids[k]].remove = True
+                    prov = self.providers[self.prov_ids[k]]
+                    if not prov.remove:
+                        print("Newer {} feed found".format(k[0]))
+                        prov.remove = True
                 else:
                     feeds.append(k[0])
 
@@ -410,12 +412,12 @@ class DataAggregator:
                         prov.clear()
                     self.writer(frame)
 
-                self.log.info("Removing provider {} with agent id {}"
-                              .format(prov.address, prov.agent_id))
+                self.log.info("Removing provider {} with session_id {}"
+                              .format(prov.address, prov.session_id))
                 pid = prov.prov_id
                 self.hksess.remove_provider(pid)
                 del self.providers[pid]
-                del self.prov_ids[(prov.address, prov.agent_id)]
+                del self.prov_ids[(prov.address, prov.session_id)]
 
             # Then write status if we need to
             if self.should_write_status:

--- a/agents/aggregator/aggregator_agent.py
+++ b/agents/aggregator/aggregator_agent.py
@@ -213,7 +213,7 @@ class DataAggregator:
                 )
                 self.providers[prov_id] = Provider(feed, prov_id)
                 self.prov_ids[(feed["address"], session_id)] = prov_id
-                self.log.info("Added provider {} (agent sess: {}) with id {}"
+                self.log.info("Added provider {} (session_id: {}) with id {}"
                               .format(feed['address'], session_id, prov_id))
                 self.should_write_status = True
                 self.agent.subscribe_to_feed(agent_address,

--- a/agents/registry/registry.py
+++ b/agents/registry/registry.py
@@ -7,8 +7,7 @@ from threading import Lock
 class RegisteredAgent:
     def __init__(self, agent_encoded):
         self.encoded = agent_encoded
-
-        for key in ['agent_session_id']:
+        for key in ['session_id']:
             setattr(self, key, self.encoded[key])
 
         self.time_registered = time.time()
@@ -93,7 +92,7 @@ class Registry:
 
         action = "added"
         if address in self.active_agents.keys():
-            if agent_data['agent_session_id'] != self.active_agents[address].agent_session_id:
+            if agent_data['session_id'] != self.active_agents[address].session_id:
                 self.log.info("Address {} is already registered. Removing old"
                               "instance and replacing it with new one"
                               .format(address))
@@ -102,8 +101,8 @@ class Registry:
                     self.remove_agent(address)
             else:
                 self.log.info("Agent with session id {} has already been registered."
-                              .format(agent_data['agent_session_id']))
-                return False, "Agent already registered with session id {}".format(agent_data['agent_session_id'])
+                              .format(agent_data['session_id']))
+                return False, "Agent already registered with session id {}".format(agent_data['session_id'])
 
         with self.lock:
             self.active_agents[address] = RegisteredAgent(agent_data)

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -211,7 +211,7 @@ class OCSAgent(ApplicationSession):
         """
         return {
             'agent_address': self.agent_address,
-            'agent_session_id': self.agent_session_id,
+            'session_id': self.agent_session_id,
             'feeds': [f[1].encoded() for f in self.feeds.items()],
             'tasks': list(self.tasks.keys()),
             'processes': list(self.processes.keys())

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -105,7 +105,7 @@ class Feed:
             "feed_name": self.feed_name,
             "address": self.address,
             "record": self.record,
-            "agent_session_id": self.agent.agent_session_id
+            "session_id": self.agent.agent_session_id
         }
 
     def flush_buffer(self):


### PR DESCRIPTION
This PR should fix issues #60 by changing the keys of the aggregator's prov_id dict from `feed_address` to `(feed_address, agent_session_id)`. This way the aggregator can avoid accidentally removing a new provider instead of an old one. I think it also fixe issue #61.

It fixed docker-compose restart with the fake-data-agent. Brian can you check if this fixes the problem with the Lakeshore agent? If it works I'll merge it.