### PR TITLE
Stream aliases

### DIFF
--- a/agents/aggregator/aggregator_agent.py
+++ b/agents/aggregator/aggregator_agent.py
@@ -1,5 +1,5 @@
 import time, threading
-from datetime import datetime
+import datetime
 import binascii
 import numpy as np
 from ocs import ocs_agent, site_config, client_t, ocs_feed
@@ -283,15 +283,17 @@ class DataAggregator:
         Starts new G3File with in directory `data_dir`.
         """
 
-        file_start_time = datetime.utcnow()
-        timestamp = file_start_time.timestamp()
-        sub_dir = os.path.join(data_dir, "{:.5}".format(str(timestamp)))
+        start_time = time.time()
+        start_datetime = datetime.datetime.fromtimestamp(start_time,
+                                                         tz=datetime.timezone.utc)
+
+        sub_dir = os.path.join(data_dir, "{:.5}".format(str(start_time)))
 
         # Create new dir for current day
         if not os.path.exists(sub_dir):
             os.makedirs(sub_dir)
 
-        time_string = file_start_time.strftime("%Y-%m-%d-%H-%M-%S")
+        time_string = start_datetime.strftime("%Y-%m-%d-%H-%M-%S")
         filename = os.path.join(sub_dir, "{}.g3".format(time_string))
 
         self.log.info("Creating file: {}".format(filename))
@@ -384,7 +386,8 @@ class DataAggregator:
                 if self.writer is not None:
                     self.end_file()
                 self.start_file(data_dir)
-                ts = datetime.utcnow().timestamp()
+                file_start_time = time.time()
+
 
             # Removes old providers if new ones exist
             keys = sorted(self.prov_ids, key=lambda x: x[1], reverse=True)
@@ -436,7 +439,7 @@ class DataAggregator:
 
 
             # Check if its time to write new frame/file
-            new_file_time = (datetime.utcnow().timestamp() - ts) > time_per_file
+            new_file_time = (time.time() - file_start_time) > time_per_file
 
         self.end_file()
         return True, 'Acquisition exited cleanly.'

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -98,6 +98,7 @@ class OCSAgent(ApplicationSession):
         self.next_session_id = 0
         self.session_archive = {} # by op_name, lists of OpSession.
         self.agent_address = address
+        self.root_address, self.instance_id = self.agent_address.split('.')
         self.registered = False
         self.log = txaio.make_logger()
         self.heartbeat_call = None
@@ -142,7 +143,7 @@ class OCSAgent(ApplicationSession):
 
     @inlineCallbacks
     def onJoin(self, details):
-        self.log.info('session joined: {}'.format(details))
+        self.log.info('session joined: {details}', details=details)
         # Get an address somehow...
         if self.agent_address is None:
             self.agent_address = 'observatory.random'

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -183,6 +183,9 @@ class HubConfig:
             Agent.  See :ref:`registry`.  (Command line override:
             ``--registry-address``.)
 
+        ``alias_file`` (optional): File containing stream aliases (Command line
+                override: ``--alias-file``.)
+
         """
         self = cls()
         self.parent = parent
@@ -292,6 +295,9 @@ def add_arguments(parser=None):
 
     ``--working-dir=...``:
         Propagate the working directory.
+        
+    ``--alias-file=...``:
+        File containing stream_aliases
 
     """
     if parser is None:
@@ -327,6 +333,9 @@ def add_arguments(parser=None):
     """Set the logging directory.""")
     group.add_argument('--working-dir', help=
     """Propagate the working directory.""")
+    group.add_argument('--alias-file', help=
+                       """Set alias file""")
+
     return parser
     
 def get_config(args, agent_class=None):
@@ -376,6 +385,9 @@ def get_config(args, agent_class=None):
 
     if args.registry_address is not None:
         site_config.hub.data['registry_address'] = args.registry_address
+
+    if args.alias_file is not None:
+        site_config.hub.data['alias_file'] = args.alias_file
 
     # Matching behavior.
     no_host_match = (agent_class == '*control*')
@@ -458,8 +470,18 @@ def reparse_args(args, agent_class=None):
         args.site_realm = site.hub.data['wamp_realm']
     if args.address_root is None:
         args.address_root = site.hub.data['address_root']
+
     if args.registry_address is None:
         args.registry_address = site.hub.data.get('registry_address')
+
+    if args.alias_file is None:
+        args.alias_file = os.path.normpath(os.path.expandvars(
+            site.hub.data.get('alias_file')))
+    elif args.alias_file.lower() == "none":
+        args.alias_file = None
+    else:
+        args.alias_file = os.path.normpath(os.path.expandvars(args.alias_file))
+
     if (args.log_dir is None) and (host is not None):
         args.log_dir = host.log_dir
 


### PR DESCRIPTION
Here's a first attempt at adding aliases into the HK data stream. The alias file can be set in the `hub` section of your site-config file, or via the command line with the `--alias-file` argument. My hub looks like this: 
```
hub:

  wamp_server: ws://localhost:8001/ws
  wamp_http: http://localhost:8001/call
  wamp_realm: test_realm
  address_root: observatory
  registry_address: observatory.registry
  alias_file: ${OCS_CONFIG_DIR}/aliases.yaml
```
which works from both within docker and on the host. 

The alias file is a yaml file with entries structured like:
```
instance-id:
    feed-name:
        stream-1: "alias-1"
        stream-2: ["alias-2.1", "alias-2.2"]
```
where you can give a single alias or list of aliases for each stream. For example, for a lakeshore240 agent you might have something like this
```
LSASIM:
  temperatures:
    "Channel 01 V": ["CHWP1_V", "D001_V"]
    "Channel 01 T": ["CHWP1_T", "D001_T"]
    "Channel 02 V": ["CHWP2_V", "D002_V"]
    "Channel 02 T": ["CHWP2_T", "D002_T"]
    "Channel 03 V": ["CHWP3_V", "D003_V"]
    "Channel 03 T": ["CHWP3_T", "D003_T"]
    "Channel 04 V": ["CHWP4_V", "D004_V"]
    "Channel 04 T": ["CHWP4_T", "D004_T"]
    "Channel 05 V": ["CHWP5_V", "D005_V"]
    "Channel 05 T": ["CHWP5_T", "D005_T"]
    "Channel 06 V": ["CHWP6_V", "D006_V"]
    "Channel 06 T": ["CHWP6_T", "D006_T"]
    "Channel 07 V": ["CHWP7_V", "D007_V"]
    "Channel 07 T": ["CHWP7_T", "D007_T"]
    "Channel 08 V": ["CHWP8_V", "D008_V"]
    "Channel 08 T": ["CHWP8_T", "D008_T"]
```

These entries are read in and saved by each OCS Feed when it's registered. The aliases for each provider are written as a G3MapVectorString in the hk status frame, so each provider object looks like:
```
{  'aliases': <spt3g.core.G3MapVectorString object at 0x7fd68074c6b8>,
   'description': <spt3g.core.G3String object at 0x7fd68074c660>,
   'prov_id': <spt3g.core.G3Int object at 0x7fd68074c978>
}
```
The only thing that I'm unsure about is whether or not we want to store the aliases in the so3g hksession providers, so that they're written to the status frame automatically. Currently, the aggregator is adding them manually to the status frame after the hksession creates it.