### PR TITLE
Docker restructure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,6 @@ FROM simonsobs/so3g:v0.0.4-32-g7b9a908
 RUN groupadd -g 9000 ocs && \
     useradd -l -u 9000 -g 9000 ocs
 
-# Set the working directory to /app
-WORKDIR /app
-
 # Setup configuration environment
 ENV OCS_CONFIG_DIR=/config
 
@@ -19,7 +16,11 @@ RUN apt-get update && apt-get install -y python3 \
     python3-pip
 
 # Copy the current directory contents into the container at /app
-COPY . /app/
+COPY . /app/ocs/
+
+WORKDIR /app
 
 # Install ocs
-RUN pip3 install -r requirements.txt .
+RUN pip3 install -r ocs/requirements.txt \
+    && pip3 install -e ocs
+

--- a/agents/aggregator/Dockerfile
+++ b/agents/aggregator/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /data && \
     chown ocs:ocs /data
 
 # Copy this local copy into place over the OCS base image
-COPY aggregator_agent.py /app/agents/aggregator/
+COPY aggregator_agent.py /app/ocs/agents/aggregator/
 
 # Run registry on container startup
 ENTRYPOINT ["python3", "-u", "aggregator_agent.py"]

--- a/agents/aggregator/Dockerfile
+++ b/agents/aggregator/Dockerfile
@@ -5,14 +5,11 @@
 FROM ocs:latest
 
 # Set the working directory to registry directory
-WORKDIR /app/agents/aggregator/
+WORKDIR /app/ocs/agents/aggregator/
 
 # Prepare data directory for mount
 RUN mkdir -p /data && \
     chown ocs:ocs /data
-
-# Copy this local copy into place over the OCS base image
-COPY aggregator_agent.py /app/ocs/agents/aggregator/
 
 # Run registry on container startup
 ENTRYPOINT ["python3", "-u", "aggregator_agent.py"]

--- a/agents/aggregator/Dockerfile
+++ b/agents/aggregator/Dockerfile
@@ -7,9 +7,13 @@ FROM ocs:latest
 # Set the working directory to registry directory
 WORKDIR /app/ocs/agents/aggregator/
 
+COPY aggregator_agent.py .
+
 # Prepare data directory for mount
 RUN mkdir -p /data && \
     chown ocs:ocs /data
+
+
 
 # Run registry on container startup
 ENTRYPOINT ["python3", "-u", "aggregator_agent.py"]

--- a/agents/fake_data/Dockerfile
+++ b/agents/fake_data/Dockerfile
@@ -7,6 +7,8 @@ FROM ocs:latest
 # Set the working directory to registry directory
 WORKDIR /app/ocs/agents/fake_data/
 
+COPY . .
+
 # Run registry on container startup
 ENTRYPOINT ["python3", "-u", "fake_data_agent.py"]
 

--- a/agents/fake_data/Dockerfile
+++ b/agents/fake_data/Dockerfile
@@ -5,7 +5,7 @@
 FROM ocs:latest
 
 # Set the working directory to registry directory
-WORKDIR /app/agents/fake_data/
+WORKDIR /app/ocs/agents/fake_data/
 
 # Run registry on container startup
 ENTRYPOINT ["python3", "-u", "fake_data_agent.py"]

--- a/agents/registry/Dockerfile
+++ b/agents/registry/Dockerfile
@@ -5,7 +5,7 @@
 FROM ocs:latest
 
 # Set the working directory to registry directory
-WORKDIR /app/agents/registry/
+WORKDIR /app/ocs/agents/registry/
 
 # Run registry on container startup
 ENTRYPOINT ["python3", "-u", "registry.py"]

--- a/agents/registry/Dockerfile
+++ b/agents/registry/Dockerfile
@@ -7,6 +7,8 @@ FROM ocs:latest
 # Set the working directory to registry directory
 WORKDIR /app/ocs/agents/registry/
 
+COPY . .
+
 # Run registry on container startup
 ENTRYPOINT ["python3", "-u", "registry.py"]
 

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -89,6 +89,7 @@ class OCSAgent(ApplicationSession):
 
     def __init__(self, config, site_args, address=None):
         ApplicationSession.__init__(self, config)
+        self.log.info("Using OCS version {v}", v=ocs.__version__)
         self.site_args = site_args
         self.tasks = {}       # by op_name
         self.processes = {}   # by op_name


### PR DESCRIPTION
This PR makes the docker containers slightly more consistent between ocs and socs agents,  and makes it easier to work in a 'development' mode where you mount in your own copy of ocs/socs.

Now in the docker containers, the ocs library is located in `/app/ocs` and the socs library in `/app/socs`. It also `pip3 install`'s the packages with the `-e` option to be editable, so you don't need to mount your dev package over the pip package separately. I've also added a log statement in OCSAgent to show which version of ocs is being used. 

I've tested this with the aggregator, registry, and LS240 agents locally. There will be a similar PR to socs to change the container structure there.