### PR TITLE
Fixed provider_session_id bug in aggregator

### DIFF
--- a/agents/aggregator/aggregator_agent.py
+++ b/agents/aggregator/aggregator_agent.py
@@ -98,7 +98,7 @@ class Provider:
             frame = core.G3Frame(core.G3FrameType.Housekeeping)
 
         frame['address'] = self.address
-        frame['session_id'] = self.session_id
+        frame['provider_session_id'] = self.session_id
 
         for block_name, block in self.blocks.items():
             if not block.timestamps:


### PR DESCRIPTION
This should fix the session_id bug in the aggregator. Brian, can you check it and make sure it fixes it for you? I tested it with the fake_data_agent. Like Matthew said we might want to write the entire frame in so3g.hk, but this will work temporarily.

Also I added the option to start the FakeDataAgent's acq on startup. 