### PR TITLE
Fix log formatting error

### DIFF
--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -143,7 +143,7 @@ class OCSAgent(ApplicationSession):
 
     @inlineCallbacks
     def onJoin(self, details):
-        self.log.info('session joined: {}'.format(details))
+        self.log.info('session joined: {x}', x=details)
         # Get an address somehow...
         if self.agent_address is None:
             self.agent_address = 'observatory.random'


### PR DESCRIPTION
This log message always produces an "Unable to format event" message in the
logs. This is due to the string format of a SessionDetails object containing
curly brackets. In the txaio logger curly brackets need to be escaped by
additional curly brackets. Here we implement this escape to properly format the
logs.

What exactly do we want to be logging from the SessionDetails? I'm wondering if this should be at a different log level.