### PR TITLE
Add bit to flip to turn agent heartbeat off

### DIFF
--- a/agents/fake_data/fake_data_agent.py
+++ b/agents/fake_data/fake_data_agent.py
@@ -124,6 +124,22 @@ class FakeDataAgent:
         return (ok, {True: 'Requested process stop.',
                      False: 'Failed to request process stop.'}[ok])
 
+    def set_heartbeat_state(self, session, params=None):
+        """Task to set the state of the agent heartbeat.
+
+        Args:
+            heartbeat (bool): True for on, False for off
+
+        """
+        # Default to on, which is what we generally want to be true
+        heartbeat_state = params.get('heartbeat', True)
+
+        self.agent._heartbeat_on = heartbeat_state
+        self.log.info("Setting heartbeat_on: {}...".format(heartbeat_state))
+
+        return True, "Set heartbeat_on: {}".format(heartbeat_state)
+
+
 
 def add_agent_args(parser_in=None):
     if parser_in is None:
@@ -154,5 +170,6 @@ if __name__ == '__main__':
                           sample_rate=args.sample_rate)
     agent.register_process('acq', fdata.start_acq, fdata.stop_acq,
                            blocking=True, startup=startup)
+    agent.register_task('set_heartbeat', fdata.set_heartbeat_state)
 
     runner.run(agent, auto_reconnect=True)

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -100,6 +100,7 @@ class OCSAgent(ApplicationSession):
         self.registered = False
         self.log = txaio.make_logger()
         self.heartbeat_call = None
+        self._heartbeat_on = True
         self.agent_session_id = str(time.time())
         self.startup_ops = []  # list of (op_type, op_name)
         self.startup_subs = []  # list of dicts with params for subscribe call
@@ -161,7 +162,10 @@ class OCSAgent(ApplicationSession):
         self.register_feed("heartbeat", max_messages=1)
 
         def heartbeat():
-            self.publish_to_feed("heartbeat", 0, from_reactor=True)
+            if self._heartbeat_on:
+                self.log.debug(' {:.1f} {address} heartbeat '
+                               .format(time.time(), address=self.agent_address))
+                self.publish_to_feed("heartbeat", 0, from_reactor=True)
 
         self.heartbeat_call = task.LoopingCall(heartbeat)
         self.heartbeat_call.start(1.0) # Calls the hearbeat every second


### PR DESCRIPTION
This adds an internal attribute for turning off an Agent's heartbeat. This is for reproducing an error state that was seen on one of the deployed test systems where an agent became unregistered with the registry, but was still running, causing the aggregator to raise an error.

We also add a debug log statement for showing the heartbeat itself, this is useful in numerous occasions, though is quite loud in the logs.