### PR TITLE
Adds some additional subscribe functionality to OCSAgent.

### DIFF
--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -470,8 +470,6 @@ class OCSAgent(ApplicationSession):
                 Feed name, e.g. `temperatures`
             handler (callable):
                 handler called with message data
-            topic (string):
-                uri of topic to subscribe to
             options (dict):
                 Dict or subscribe options. See https://autobahn.readthedocs.io/en/latest/reference/autobahn.wamp.html#autobahn.wamp.types.SubscribeOptions
             force_subscribe (bool):


### PR DESCRIPTION
This PR adds some convenient subscribe functions to the OCSAgent. 

- It overrides the OCSAgent subscribe function to prevent re-subscription to topics by default.
This is important for the aggregator, and agents where the init function might be called multiple times.

- It adds a `subscribe_on_start` function, that tells the OCSAgent to immediately subscribe to 
a particular feed on join so you don't have to call it from an init task.

- Adds easier subscription options to `subscribe_to_feed`, so to do pattern matching, you can just add the argument `option={'match': 'wildcard'}` or `option={'match': 'prefix'}`