### PR TITLE
Aggregator 2.0

### DIFF
--- a/agents/aggregator/aggregator_agent.py
+++ b/agents/aggregator/aggregator_agent.py
@@ -1,14 +1,9 @@
-import time, threading
-import datetime
-import binascii
-import numpy as np
-from ocs import ocs_agent, site_config, client_t, ocs_feed
-import os
-
-from twisted.internet.defer import inlineCallbacks
-from twisted.internet import reactor
+import time, datetime, binascii, os, queue, argparse
 from threading import RLock
+from typing import Dict
 
+from ocs import ocs_agent, site_config, ocs_feed
+import argparse
 if os.getenv('OCS_DOC_BUILD') != 'True':
     from spt3g import core
     import so3g
@@ -18,71 +13,108 @@ class Provider:
     """
     Stores data for a single provider (OCS Feed).
 
-    Attributes:
+    Args:
         addresss (string):
-            Full address of the Provider feed
-        session_id (string):
-            session_id of agent who owns the Feed
+            Full address of the provider
+        sessid (string):
+            session_id of the provider
         frame_length (float):
             Time before data should be written into a frame
-        remove (bool):
-            If set true, Provider will be written to disk and deleted
-            next iteration of the aggregator
-        frame_start_time (float):
-            Start time of current frame
+        prov_id (bool):
+            id assigned to the provider by the HKSessionHelper
+
+    Attributes:
+
         blocks (dict):
             All blocks that are written by provider.
+        frame_start_time (float):
+            Start time of current frame
+        fresh_time (float):
+            time (in seconds) that the provider can go without data before being
+            labeled stale, and scheduled to be removed
+        last_refresh (time):
+            Time when the provider was last refreshed (either through data or
+            agent heartbeat).
     """
-    def __init__(self, feed, prov_id):
+    def __init__(self, address, sessid, frame_length, prov_id):
+        self.address = address
+        self.sessid = sessid
+        self.frame_length = frame_length
         self.prov_id = prov_id
 
-        self.address = feed['address']
-        self.session_id = feed['session_id']
-        self.frame_length = feed['agg_params']['frame_length']
+        self.blocks = {}
 
-        self.lock = RLock()
+        self._lock = RLock()
 
         # When set to True, provider will be written and removed next agg cycle
-        self.remove = False
         self.frame_start_time = None
-        self.blocks = {}
+
+        # 1 min without refresh (data) will mark the provider
+        # as stale, and it'll be flushed and removed next cycle.
+        self.fresh_time = 3*60
+        self.last_refresh = time.time() # Determines if
+
+
+    def refresh(self):
+        """ Refresh provider """
+        self.last_refresh = time.time()
+
+    def stale(self):
+        """Returns true if provider is stale and should be removed"""
+        return (time.time() - self.last_refresh) > self.fresh_time
+
+    def new_frame_time(self):
+        """Returns true if its time for a new frame to be written"""
+        if self.frame_start_time is None:
+            return False
+
+        return (time.time() - self.frame_start_time) > self.frame_length
+
+    def empty(self):
+        """Returns true if all blocks are empty"""
+        with self._lock:
+            for _,b in self.blocks():
+                if not b.empty():
+                    return False
+
+        return True
 
     def write(self, data):
         """
         Saves a list of data points into blocks.
         A block will be created for any new block_name.
         """
+        self.refresh()
+        with self._lock:
 
-        if self.frame_start_time is None:
-            # Get min frame time out of all blocks
-            self.frame_start_time = time.time()
-            for _,b in data.items():
-                if b['timestamps']:
-                    self.frame_start_time = min(self.frame_start_time, b['timestamps'][0])
+            if self.frame_start_time is None:
+                # Get min frame time out of all blocks
+                self.frame_start_time = time.time()
+                for _,b in data.items():
+                    if b['timestamps']:
+                        self.frame_start_time = min(self.frame_start_time, b['timestamps'][0])
 
-        for key,block in data.items():
-            try:
-                b = self.blocks[key]
-            except KeyError:
-                self.blocks[key] = ocs_feed.Block(
-                    key, block['data'].keys(),
-                    prefix=block['prefix']
-                )
-                b = self.blocks[key]
+            for key,block in data.items():
+                try:
+                    b = self.blocks[key]
+                except KeyError:
+                    self.blocks[key] = ocs_feed.Block(
+                        key, block['data'].keys(),
+                        prefix=block['prefix']
+                    )
+                    b = self.blocks[key]
 
-            b.extend(block)
-
+                b.extend(block)
 
     def clear(self):
-        """
-        Clears all blocks and resets the frame_start_time
-        """
-        for _,b in self.blocks.items():
-            b.clear()
+        """Clears all blocks and resets the frame_start_time"""
+        with self._lock:
+            for _,b in self.blocks.items():
+                b.clear()
 
-        self.frame_start_time = None
+            self.frame_start_time = None
 
-    def to_frame(self, hksess=None):
+    def to_frame(self, hksess=None, clear=False):
         """
         Returns a G3Frame based on the provider's blocks.
 
@@ -90,391 +122,396 @@ class Provider:
             hksess (optional):
                 If provided, the frame will be based off of hksession's data frame.
                 If the data will be put into a clean frame.
+            clear (bool):
+                Clears provider data if True.
 
         """
-        if hksess is not None:
-            frame = hksess.data_frame(prov_id=self.prov_id)
-        else:
-            frame = core.G3Frame(core.G3FrameType.Housekeeping)
+        with self._lock:
 
-        frame['address'] = self.address
-        frame['provider_session_id'] = self.session_id
+            if hksess is not None:
+                frame = hksess.data_frame(prov_id=self.prov_id)
+            else:
+                frame = core.G3Frame(core.G3FrameType.Housekeeping)
 
-        for block_name, block in self.blocks.items():
-            if not block.timestamps:
-                continue
+            frame['address'] = self.address
+            frame['provider_session_id'] = self.sessid
 
-            hk = so3g.IrregBlockDouble()
-            hk.prefix = block.prefix
-            hk.t = block.timestamps
-            for key, ts in block.data.items():
-                hk.data[key] = ts
+            for block_name, block in self.blocks.items():
+                if not block.timestamps:
+                    continue
 
-            frame['blocks'].append(hk)
+                hk = so3g.IrregBlockDouble()
+                hk.prefix = block.prefix
+                hk.t = block.timestamps
+                for key, ts in block.data.items():
+                    hk.data[key] = ts
 
-        return frame
+                frame['blocks'].append(hk)
+
+            if clear:
+                self.clear()
+
+            return frame
 
 
-class DataAggregator:
+class G3FileRotator(core.G3Module):
     """
-    The Data Aggregator Agent listens to data provider feeds, and outputs the housekeeping data as G3Frames.
+    G3 module which handles file rotation.
+    After time_per_file has elapsed, the rotator will end that file and create
+    a new file with the `filename` function.
+    It will write the last_session and last_status frame to any new file if they
+    exist.
+
+    Args:
+        time_per_file (float):
+            time (seconds) before a new file should be written
+        filename (callable):
+            function that generates new filenames.
+    """
+    def __init__(self, time_per_file, filename):
+        self.time_per_file = time_per_file
+        self.filename = filename
+
+        self.file_start_time = None
+        self.writer = None
+        self.last_session = None
+        self.last_status = None
+
+    def flush(self):
+        """Flushes current g3 file to disk"""
+        if self.writer is not None:
+            self.writer.Flush()
+
+    def Process(self, frame):
+        """
+        Writes frame to current file. If file has not been started
+        or time_per_file has elapsed, file is closed and a new file is created
+        by `filename` function passed to constructor
+        """
+        ftype = frame['hkagg_type']
+
+        if ftype == so3g.HKFrameType.session:
+            self.last_session = frame
+        elif ftype == so3g.HKFrameType.status:
+            self.last_status = frame
+
+        if self.writer is None:
+            self.writer = core.G3Writer(self.filename())
+            self.file_start_time = time.time()
+
+            if ftype in [so3g.HKFrameType.data, so3g.HKFrameType.status]:
+                if self.last_session is not None:
+                    self.writer(self.last_session)
+
+            if ftype == so3g.HKFrameType.data:
+                if self.last_status is not None:
+                    self.writer(self.last_status)
+
+        self.writer(frame)
+
+        if (time.time() - self.file_start_time) > self.time_per_file:
+            self.writer = None
+
+
+class Aggregator:
+    """
+    The Data Aggregator Agent listens to data provider feeds, and outputs the
+    housekeeping data as G3Frames.
+
+    Args:
+        args (namespace):
+            args from the function's argparser.
+        log:
+            logger from the agent
 
     Attributes:
 
         providers (dict):
             All active providers that the aggregator is subscribed to.
-        next_prov_id (int):
-            Stores the prov_id to be used on the next registered agent
+            Indexed by provider id.
+        pids (dict):
+            Dictionary of provider id's.
+            Indexed by provider's (address, sessid).
         hksess (so3g HKSession):
             The so3g HKSession that generates status, session, and data frames.
         aggregate (bool):
            Specifies if the agent is currently aggregating data.
-        writer (G3File):
-            Writer for the current G3File
+        rotator (G3FileRotator):
+            module for writing G3Files.
+        frame_queue (queue.Queue):
+            queue of frames to be written to disk. Every loop iteration in `run`
+            this will be cleared and all frames will be written to disk.
+        data_dir (path):
+            base directory for hk data.
     """
+    def __init__(self, args, log):
+        self.log = log
+        self.frame_queue = queue.Queue()
 
-    def __init__(self, agent, time_per_file, data_dir):
+        self.data_dir = args.data_dir
+        self._loop_time = 1
 
-        self.agent = agent
-        self.log = agent.log
+        self.rotator = G3FileRotator(int(args.time_per_file), self._make_filename)
+        self.aggregate = False
 
-        self.time_per_file = time_per_file
-        self.data_dir = data_dir
+        self.providers: Dict[Provider] = {} # by prov_id
+        self.pids = {}  # By (address, sessid)
 
-        self.providers = {} # by prov_id
-        self.prov_ids = {} # by (address, session_id)
-        self.next_prov_id = 0
-
-        self.should_write_status =False
         self.hksess = so3g.hk.HKSessionHelper(description="HK data")
 
-        self.aggregate = False
-        self.writer = None
-
-    def _data_handler(self, _data):
+    def _make_filename(self, make_subdirs=True):
         """
-        Callback for whenever data is published to an aggregator feed.
-
-        If the feed is already buffered, the data handler will immediately
-        write it to a G3Frame when this is called.
-
-        If the feed is not buffered, it will add the data-point to the
-        buffer in the correct block.
-        """
-        if not self.aggregate:
-            return
-
-        data, feed = _data
-        prov_id = self.prov_ids[(feed["address"], feed["session_id"])]
-        prov = self.providers[prov_id]
-
-        prov.lock.acquire()
-        prov.write(data)
-        prov.lock.release()
-
-    def _new_agent_handler(self, _data):
-        """
-            Callback for whenever the registry publishes new agent status.
-
-            If the agent has not yet been subscribed to and has an aggregated
-            feed, this will add it to `self.providers` and subscribe to the
-            feed.
-        """
-
-        (action, agent_data), feed_data = _data
-        agent_address = agent_data['agent_address']
-        session_id = agent_data['session_id']
-
-        self.log.debug("Agent activity --- Agent: {}, session_id: {}, action: {}"
-                      .format(agent_address, session_id, action))
-
-        for feed in agent_data['feeds']:
-            if not feed['record']:
-                continue
-
-            pid = self.prov_ids.get((feed["address"], session_id))
-            if pid is not None:
-                prov = self.providers[pid]
-            else:
-                prov = None
-
-            if action == 'removed' and prov is not None:
-                self.log.info("Scheduled remove for provider {} ({})"
-                              .format(feed['address'], session_id))
-                prov.remove = True
-
-            if action in ['added', 'status']:
-                if prov is not None:
-                    self.log.warn("Provider {} ({}) already exists.".format(feed['address'], session_id))
-                    return
-
-                prov_id = self.hksess.add_provider(
-                    description="{}".format(feed['address'])
-                )
-                self.providers[prov_id] = Provider(feed, prov_id)
-                self.prov_ids[(feed["address"], session_id)] = prov_id
-                self.log.info("Added provider {} (session_id: {}) with id {}"
-                              .format(feed['address'], session_id, prov_id))
-                self.should_write_status = True
-                self.agent.subscribe_to_feed(agent_address,
-                                             feed['feed_name'],
-                                             self._data_handler)
-
-    def add_feed(self, session, params={}):
-        """
-        Task to subscribe to a feed.
-
-        Arguments:
-            address (str):
-                Full address of the feed
-            frame_length:
-                Time before frames should be written to disk
-        """
-        agent_addr, feed_name = params['address'].split('.feeds.')
-        prov_id = self.hksess.add_provider(
-            description="{}".format(params['address'])
-        )
-
-        x = {
-            'session_id': -1,
-            'address': params['address'],
-            'frame_length': params['frame_length'],
-        }
-
-        self.providers[prov_id] = Provider(x, prov_id)
-        self.agent.subscribe_to_feed(agent_addr,
-                                     feed_name,
-                                     self._data_handler)
-        self.should_write_status = True
-        return True, "Feed added"
-
-    def initialize(self, session, params=None):
-        """TASK: Subscribes to `agent_activity` feed and has registry dump
-        info on all active agents.  Optionally starts the "record"
-        Process.
-
-        ``params`` is a dict with the following keys:
-
-        - 'start_record' (bool, optional): Default is False.  If True,
-            start the "record" Process after performing registration.
-        """
-        if params is None:
-            params = {}
-
-        reg_address = self.agent.site_args.registry_address
-
-        if reg_address is None:
-            self.log.warn("No registry address is in site args")
-            return True, "Initialized Aggregator"
-
-        self.agent.subscribe_to_feed(reg_address,
-                                     'agent_activity',
-                                     self._new_agent_handler)
-
-        self.agent.call_op(reg_address, 'dump_agent_info', 'start')
-
-        if params.get('start_record', False):
-            self.agent.start('record')
-
-        return True, "Initialized Aggregator"
-
-    def start_file(self, data_dir):
-        """
-        Starts new G3File with in directory `data_dir`.
-        """
-
-        start_time = time.time()
-        start_datetime = datetime.datetime.fromtimestamp(start_time,
-                                                         tz=datetime.timezone.utc)
-
-        sub_dir = os.path.join(data_dir, "{:.5}".format(str(start_time)))
-
-        # Create new dir for current day
-        if not os.path.exists(sub_dir):
-            os.makedirs(sub_dir)
-
-        time_string = start_datetime.strftime("%Y-%m-%d-%H-%M-%S")
-        filename = os.path.join(sub_dir, "{}.g3".format(time_string))
-
-        self.log.info("Creating file: {}".format(filename))
-        self.writer = core.G3Writer(filename)
-
-        session_frame = self.hksess.session_frame()
-        self.writer(session_frame)
-
-        self.write_status()
-
-    def write_status(self):
-        """
-        Writes hksess status frame to disk and sets write_status flag to False
-        """
-        if self.writer is None:
-            return
-
-        status = self.hksess.status_frame()
-        self.writer(status)
-        self.should_write_status = False
-
-    def end_file(self):
-        """
-        Writes all non-empty providers to disk, clears them,
-        and then writes an EndProcessing frame
-        """
-        self.log.info("Ending file")
-
-        for pid, prov in self.providers.items():
-            if prov.frame_start_time is None:
-                continue
-
-            with prov.lock:
-                frame = prov.to_frame(self.hksess)
-                prov.clear()
-
-            self.writer(frame)
-
-        self.writer(core.G3Frame(core.G3FrameType.EndProcessing))
-        self.writer = None
-
-        return
-
-    def start_aggregate(self, session, params={}):
-        """
-        PROCESS: Starts the aggregation process.
+        Creates a new filename based on the time and base_dir.
+        If make_subdirs is True, all subdirectories will be automatically created.
+        I don't think there's any reason that this shouldn't be true...
 
         Args:
-            time_per_file (int, optional):
-                Specifies how much time should elapse before starting a new
-                file (in seconds). Defaults to 1 hr.
-
-            time_per_frame (int, optional):
-                Specifies how much time should elapse before starting a new
-                frame (in seconds). Defaults to 10 minutes.
-
-            data_dir (string, optional):
-                Path of directory to store data. Defaults to 'data/'.
+            make_subdirs (bool):
+                True if func should automatically create non-existing subdirs.
         """
-        if params is None:
-            params = {}
+        start_time = time.time()
+        start_datetime = datetime.datetime.fromtimestamp(
+            start_time, tz=datetime.timezone.utc
+        )
 
-        time_per_file = params.get("time_per_file", self.time_per_file) # [s]
-        data_dir = params.get("data_dir", self.data_dir)
+        subdir = os.path.join(self.data_dir, "{:.5}".format(str(start_time)))
 
-        self.log.info("Starting data aggregation in directory {}".format(data_dir))
-        session.set_status('running')
+        if not os.path.exists(subdir):
+            if make_subdirs:
+                os.makedirs(subdir)
+            else:
+                raise FileNotFoundError("Subdir {} does not exist"
+                                        .format(subdir))
 
-        self.hksess.start_time = time.time()
-        # Encode a suitable agg_session_id.  if 1:
-        elements = [(int(self.hksess.start_time), 32),
-                    (os.getpid(), 14),
-                    (binascii.crc32(bytes(self.hksess.description, 'utf8')), 14)]
+        time_string = start_datetime.strftime("%Y-%m-%d-%H-%M-%S")
+        filename = os.path.join(subdir, "{}.g3".format(time_string))
+        self.log.info("Creating file {} ...".format(filename))
+        return filename
+
+    def write_status(self):
+        """Adds a status frame to the frame_queue"""
+        self.frame_queue.put(self.hksess.status_frame())
+
+    def add_provider(self, prov_address, prov_sessid, frame_length):
+        """
+        Registers a new provider and writes a status frame.
+
+        Args:
+            prov_address (str):
+                full address of provider
+            prov_sessid (str):
+                session id of provider
+            frame_length (float):
+                time (sec) per data frame.
+        """
+        pid = self.hksess.add_provider(description=prov_address)
+
+        self.providers[pid] = Provider(
+            prov_address, prov_sessid, frame_length, pid
+        )
+        self.log.info("Adding provider {}".format(prov_address))
+
+        self.pids[(prov_address, prov_sessid)] = pid
+        self.write_status()
+
+        return pid
+
+    def remove_provider(self, prov):
+        """
+        Writes remaining provider data to frame and removes provider.
+
+        Args:
+            prov (Provider):
+                provider object that should be removed.
+        """
+        pid = prov.prov_id
+        addr, sessid = prov.address, prov.sessid
+
+        if not prov.empty():
+            self.frame_queue.put(prov.to_frame(self.hksess, clear=False))
+
+        self.hksess.remove_provider(pid)
+        del self.providers[pid]
+        del self.pids[(addr, sessid)]
+        self.write_status()
+
+    def write_data(self, data, pid):
+        """
+        Writes all blocks in data message to provider
+
+        Args:
+            data (list):
+                list of Blocks' that should be written to the provider.
+            pid (int):
+                prov_id of provider
+        """
+        if not self.aggregate:
+            return False
+
+        prov = self.providers[pid]
+        prov.write(data)
+
+    def remove_stale_providers(self):
+        """
+        Loops through all providers and check if they've gone stale.
+        If they have, write their remaining data to disk (they shouldn't have any)
+        and delete them.
+        """
+        stale_provs = []
+
+        for pid, prov in self.providers.items():
+            if prov.stale():
+                self.log.info("Provider {} went stale".format(prov.address))
+                stale_provs.append(prov)
+
+        for prov in stale_provs:
+            self.remove_provider(prov)
+
+    def write_providers_to_queue(self, clear=True, write_all=False):
+        """
+        Loop through all providers, and write their data to the frame_queue
+        if they have surpassed their frame_time, or if write_all is True.
+
+        Args:
+            clear (bool):
+                If True, provider data is cleared after write
+            write_all (bool):
+                If true all providers are written to disk regardless of whether
+                frame_time has passed.
+        """
+        for pid, prov in self.providers.items():
+            if write_all or prov.new_frame_time():
+                self.frame_queue.put(prov.to_frame(self.hksess, clear=clear))
+
+    def write_queue_to_disk(self):
+        """
+        Loops through frame_queue and writes them to disk.
+        """
+        while not self.frame_queue.empty():
+            self.rotator.Process(self.frame_queue.get())
+
+    def generate_id(self):
+        """
+        Generates a unique session id based on the start_time, process_id,
+        and hksess description.
+        """
+        # Maybe this should go directly into HKSessionHelper
+        elements = [
+            (int(self.hksess.start_time), 32),
+            (os.getpid(), 14),
+            (binascii.crc32(bytes(self.hksess.description, 'utf8')), 14)
+        ]
         agg_session_id = 0
         for i, b in elements:
-            agg_session_id = (agg_session_id << b) | (i % (1<<b))
-        self.log.info("New aggregator session_id=%i" % agg_session_id)
-        # The cast here to G3Int can be dropped in the future -- spt3g
-        # was updated on May 1 2019 to handle direct puts of int64_t.
-        self.hksess.session_id = core.G3Int(agg_session_id)
+            agg_session_id = (agg_session_id << b) | (i % (1 << b))
+        return agg_session_id
 
-        new_file_time = True
+    def run(self):
+        """
+        Runs aggregation until `stop` is called. This should run in a worker
+        thread.
+        """
+        self.log.info("Aggregator running...")
+        self.hksess.start_time = time.time()
+        self.hksess.session_id = self.generate_id()
+
+        self.rotator.Process(self.hksess.session_frame())
 
         self.aggregate = True
-
         while self.aggregate:
-            time.sleep(1)
+            time.sleep(self._loop_time)
 
-            if new_file_time:
-                if self.writer is not None:
-                    self.end_file()
-                self.start_file(data_dir)
-                file_start_time = time.time()
+            self.remove_stale_providers()
+            self.write_providers_to_queue()
+            self.write_queue_to_disk()
+
+            self.rotator.flush()
+
+        self.write_providers_to_queue(write_all=True)
+        self.write_queue_to_disk()
+
+        return True
+
+    def stop(self):
+        """Signals for aggregation to stop."""
+        self.aggregate = False
 
 
-            # Removes old providers if new ones exist
-            keys = sorted(self.prov_ids, key=lambda x: x[1], reverse=True)
-            feeds = []
-            for k in keys:
-                if k[0] in feeds:
-                    prov = self.providers[self.prov_ids[k]]
-                    if not prov.remove:
-                        print("Newer {} feed found".format(k[0]))
-                        prov.remove = True
-                else:
-                    feeds.append(k[0])
+class AggregatorAgent:
+    def __init__(self, agent, args):
+        self.agent: ocs_agent.OCSAgent = agent
+        self.log = agent.log
 
-            to_remove = [p for _, p in self.providers.items() if p.remove]
-            if to_remove != []:
-                self.should_write_status = True
+        self.aggregator = Aggregator(args, self.log)
 
-            # If any providers have been removed, write those to disk first
-            # And remove provider from hksess
-            prov : Provider
-            for prov in to_remove:
-                if prov.frame_start_time is not None:
-                    with prov.lock:
-                        frame = prov.to_frame(self.hksess)
-                        prov.clear()
-                    self.writer(frame)
+        # SUBSCRIBES TO ALL FEEDS!!!!
+        # If this ends up being too much data, we can add a tag '.record'
+        # at the end of the address of recorded feeds, and filter by that.
+        self.agent.subscribe_on_start(self.data_handler,
+                                      'observatory..feeds.',
+                                      options={'match': 'wildcard'})
 
-                self.log.info("Removing provider {} with session_id {}"
-                              .format(prov.address, prov.session_id))
-                pid = prov.prov_id
-                self.hksess.remove_provider(pid)
-                del self.providers[pid]
-                del self.prov_ids[(prov.address, prov.session_id)]
+        record_on_start = (args.initial_state == 'record')
+        self.agent.register_process('record', self.start_aggregate, self.stop_aggregate,
+                                    startup=record_on_start)
 
-            # Then write status if we need to
-            if self.should_write_status:
-                self.write_status()
+    def data_handler(self, _data):
+        data, feed = _data
 
-            # Write to disk any active providers that have surpassed frame_length
-            for pid, prov in self.providers.items():
-                if prov.frame_start_time is None:
-                    continue
+        if not feed['record']:
+            return
 
-                if prov.remove or (time.time() - prov.frame_start_time > prov.frame_length):
-                    with prov.lock:
-                        frame = prov.to_frame(self.hksess)
-                        prov.clear()
-                    self.writer(frame)
+        address = feed['address']
+        sessid = feed['session_id']
+        frame_length = feed['agg_params']['frame_length']
 
-            self.writer.Flush()
+        pid = self.aggregator.pids.get((address, sessid))
 
-            # Check if its time to write new frame/file
-            new_file_time = (time.time() - file_start_time) > time_per_file
+        if pid is None:
+            pid = self.aggregator.add_provider(address, sessid, frame_length)
 
-        self.end_file()
-        return True, 'Acquisition exited cleanly.'
+        self.aggregator.write_data(data, pid)
+
+    def start_aggregate(self, session, params=None):
+        """
+        Process for starting data aggregation
+        """
+        self.aggregator.run()
+        return True, "Aggregation has ended"
 
     def stop_aggregate(self, session, params=None):
-        self.aggregate = False
-        return (True, "Stopped aggregation")
+        self.aggregator.stop()
+        return True, "Stopping aggregation"
+
+
+def make_parser(parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser()
+
+    pgroup = parser.add_argument_group('Agent Options')
+    pgroup.add_argument('--data-dir',
+                        help="Base directory to store data. "
+                             "Subdirectories will be made here.")
+    pgroup.add_argument('--initial-state',
+                        default='idle',choices=['idle', 'record'],
+                        help="Initial state of argument parser. Can be either"
+                             "idle or record")
+    pgroup.add_argument('--time-per-file', default='3600',
+                        help="Time per file in seconds. Defaults to 1 hr")
+
+    return parser
 
 
 if __name__ == '__main__':
     parser = site_config.add_arguments()
 
-    # Add options specific to this agent.
-    pgroup = parser.add_argument_group('Agent Options')
-    pgroup.add_argument('--initial-state', default='idle',
-                        choices=['idle', 'record'])
-    pgroup.add_argument('--time-per-file', default='3600')
-    pgroup.add_argument('--data-dir', default='data/')
+    parser = make_parser(parser)
 
     args = parser.parse_args()
+
     site_config.reparse_args(args, 'AggregatorAgent')
 
     agent, runner = ocs_agent.init_site_agent(args)
 
-    data_aggregator = DataAggregator(agent, int(args.time_per_file), args.data_dir)
-
-    # Run 'initialize' Task and start 'record' Process?
-    init_params = False
-    if args.initial_state == 'record':
-        init_params = {'start_record': True}
-
-    agent.register_task('initialize', data_aggregator.initialize,
-                        blocking=False, startup=init_params)
-    agent.register_task('add_feed', data_aggregator.add_feed)
-    agent.register_process('record', data_aggregator.start_aggregate, data_aggregator.stop_aggregate)
-
+    data_aggregator = AggregatorAgent(agent, args)
     runner.run(agent, auto_reconnect=True)

--- a/agents/aggregator/aggregator_agent.py
+++ b/agents/aggregator/aggregator_agent.py
@@ -177,6 +177,10 @@ class G3FileRotator(core.G3Module):
         self.last_session = None
         self.last_status = None
 
+    def close_file(self):
+        self.writer(core.G3Frame(core.G3FrameType.EndProcessing))
+        self.writer = None
+
     def flush(self):
         """Flushes current g3 file to disk"""
         if self.writer is not None:
@@ -210,7 +214,7 @@ class G3FileRotator(core.G3Module):
         self.writer(frame)
 
         if (time.time() - self.file_start_time) > self.time_per_file:
-            self.writer = None
+            self.close_file()
 
 
 class Aggregator:
@@ -429,6 +433,8 @@ class Aggregator:
 
         self.write_providers_to_queue(write_all=True)
         self.write_queue_to_disk()
+
+        self.rotator.close_file()
 
         return True
 

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -14,6 +14,10 @@ class Block:
             k: [] for k in keys
         }
 
+    def empty(self):
+        """ Returns true if block is empty"""
+        return self.timestamps == []
+
     def clear(self):
         """
         Empties block's buffers


### PR DESCRIPTION
This is a refactoring of the HK Aggregator which I've been wanting to do for a while. The main goals of the rewrite are to:

 - Separate the aggregator logic from crossbar, and divide it into clearly defined and easily testable functions instead of having most of the logic being in the `run` task, so it is easier to debug.
- Change the way in which providers are handled. In this new version, the aggregator doesn't rely on the registry to get feed data. Instead it listens to all feeds using wildcard matching, and if they are "recorded feeds" it registers the provider automatically. If it doesn't get any data from the provider in some amount of time (right now its hardcoded to 3 min, but maybe it should be a feed option), the provider is marked as stale and removed. I think this is fine, since as soon as it starts sending data again, the aggregator will automatically re-register it, with the only difference being the HKSession internal provider id.

I wanted to add the tests in this PR, but I'm having trouble updating so3g to python3.7 on my laptop, so I'll need to dockerize the tests which I think might be out of the scope of this PR. Hopefully this will solve a lot of the registration problems that we are having (i.e. #75, #74, #67)