### PR TITLE
Adds parse_arguments function to site_config

### DIFF
--- a/agents/fake_data/fake_data_agent.py
+++ b/agents/fake_data/fake_data_agent.py
@@ -140,15 +140,8 @@ def add_agent_args(parser_in=None):
     return parser_in
 
 if __name__ == '__main__':
-    parser = site_config.add_arguments()
-
-    add_agent_args(parser)
-
-    # Parse comand line.
-    args = parser.parse_args()
-
-    # Interpret options in the context of site_config.
-    site_config.reparse_args(args, 'FakeDataAgent')
+    parser = add_agent_args()
+    args = site_config.parse_args(agent_class='FakeDataAgent', parser=parser)
 
     startup = False
     if args.mode == 'acq':


### PR DESCRIPTION
This parses arguments from both the command line and then site-config
file simultaneously, and passes them through the argparse.ArgumentParser so that they
can be interpreted with the correct argparse options.

Changed fake_data_agent.py to demonstrate how to use it. For instance, in the fake data agent this makes it so num_channels is always interpreted as an `int` regardless of whether it comes from the site_config file or the command line, and enforces that `mode` is actually either `idle` or `acq`.

This should fix issues #77 and #30.