### PR TITLE
Aggregator session data

### DIFF
--- a/agents/aggregator/aggregator_agent.py
+++ b/agents/aggregator/aggregator_agent.py
@@ -76,7 +76,12 @@ class AggregatorAgent:
         session.set_status('starting')
         self.aggregate = True
 
-        aggregator = Aggregator(self.incoming_data, self.time_per_file, self.data_dir)
+        aggregator = Aggregator(
+            self.incoming_data,
+            self.time_per_file,
+            self.data_dir,
+            session=session
+        )
 
         session.set_status('running')
         while self.aggregate:

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -77,6 +77,8 @@ class Feed:
             Params:
                 **frame_length** (float):
                     Deterimes the amount of time each G3Frame should be (in seconds).
+                **fresh_time** (float)
+                    Time until feed is considered stale by aggregator.
 
         buffer_time (int, optional):
             Specifies time that messages should be buffered in seconds.


### PR DESCRIPTION
This PR starts to add aggregator data to the session object. Currently, the session.data object contains 
 - The current file being written
 - The last refresh time, last block_name, and is_stale for every provider that it is monitoring.

I figured we want to monitor providers even after they're stale so that their data shows up in the session object, so I changed when providers were removed. In the new version, stale providers are not removed, and providers are only removed when the aggregator detects a new provider of the same address with a larger (newer) session_id. This way the aggregator will keep track of all providers it has detected throughout its lifetime, but if a new provider with the same address is detected, the old one will be removed and replaced. I think this is ok, because its not possible to have multiple agents with the same instance-id running simultaneously.

@mhasself If there's more info you want me to include in the session data variable for the web monitor let me know!