### PR TITLE
Add instance-id as MatchedClient attribute

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,6 +72,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# Have __init__ and class docstrings both show up
+autoclass_content = "both"
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/ocs/matched_client.py
+++ b/ocs/matched_client.py
@@ -42,31 +42,44 @@ def opname_to_attr(name):
 
 
 class MatchedClient:
+    """A convenient form of an OCS client, facilitating task/process calls.
+
+    A MatchedClient is a general OCS Client that 'matches' an agent's
+    tasks/processes to class attributes, making it easy to setup a client
+    and call associated tasks and processes.
+
+    Example:
+        This example sets up a MatchedClient and calls a 'matched' task
+        (init_lakeshore) and process (acq)::
+
+            >>> client = MatchedClient('thermo1', client_type='http',
+            ...                        args=[])
+            >>> client.init_lakeshore.start()
+            >>> client.init_lakeshore.wait()
+            >>> client.acq.start(sampling_frequency=2.5)
+
+    Attributes:
+        instance_id (str): Instance id for agent to run
+
+    """
+
     def __init__(self, instance_id, **kwargs):
-        """
-        A general Matched Client that sets an agent's tasks/processes as attributes.
-        To run ::
-
-            client = MatchedClient('thermo1', client_type='http', args=[])
-
-            client.init_lakeshore.start()
-            client.init_lakeshore.wait()
-
-            client.acq.start(sampling_frequency=2.5)
+        """MatchedClient __init__ function.
 
         Args:
-
-            instance_id (string): Instance id for agent to run
+            instance_id (str): Instance id for agent to run
             args (list or args object, optional):
-                    Takes in the parser arguments for the client.
-                    If None, reads from command line.
-                    If list, reads in list elements as arguments.
-                    Defaults to None.
-                    To run in jupyter, specify args=[].
+                Takes in the parser arguments for the client.
+                If None, reads from command line.
+                If list, reads in list elements as arguments.
+                Defaults to None.
+                To run in jupyter, specify args=[].
 
-            For additional kwargs see site_config.get_control_client
+        For additional kwargs see site_config.get_control_client.
+
         """
         self._client = site_config.get_control_client(instance_id, **kwargs)
+        self.instance_id = instance_id
 
         for name, session, encoded in self._client.get_tasks():
             setattr(self, opname_to_attr(name),

--- a/ocs/matched_client.py
+++ b/ocs/matched_client.py
@@ -73,7 +73,6 @@ class MatchedClient:
                 If None, reads from command line.
                 If list, reads in list elements as arguments.
                 Defaults to None.
-                To run in jupyter, specify args=[].
 
         For additional kwargs see site_config.get_control_client.
 


### PR DESCRIPTION
Very small patch to expose instance_id as a class attribute for MatchedClients.
Mostly @jlashner, can you read my description of a matched client and verify
it's accurate/improve it?

Commit message:
> I found this helpful to have when controlling many agents in a client, as you
> can use it to identify a client when issuing repeated commands to many similar
> clients.
> 
> I also add some more description of MatchedClient in the docs and do some
> formatting.