### PR TITLE
Feed type checking

### DIFF
--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -237,5 +237,11 @@ class Feed:
         valid_types = (float, int)
 
         for k, v in message['data'].items():
-            if not all(isinstance(x, valid_types) for x in v):
-                raise ValueError("message 'data' block contains invalid data type")
+            # multi-sample check
+            if isinstance(v, list):
+                if not all(isinstance(x, valid_types) for x in v):
+                    raise ValueError("message 'data' block contains invalid data type")
+            # single sample check
+            else:
+                if not isinstance(v, valid_types):
+                    raise ValueError("message 'data' block contains invalid data type")

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -193,6 +193,9 @@ class Feed:
                                           timestamp=timestamp)
 
         if self.record:
+            # check message contents
+            Feed.verify_message_data_type(message)
+
             # Data is stored in Block objects
             block_name = message['block_name']
             try:
@@ -219,3 +222,20 @@ class Feed:
         else:
             # Publish message immediately
             self.agent.publish(self.address, (message, self.encoded()))
+
+    @staticmethod
+    def verify_message_data_type(message):
+        """Aggregated Feeds can only store certain types of data. Here we check
+        that the type of all data contained in a message's 'data' dictionary are
+        supported types.
+
+        Args:
+            message (dict):
+                Data to be published (see Feed.publish_message for details).
+
+        """
+        valid_types = (float, int)
+
+        for k, v in message['data'].items():
+            if not all(isinstance(x, valid_types) for x in v):
+                raise ValueError("message 'data' block contains invalid data type")

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -240,8 +240,14 @@ class Feed:
             # multi-sample check
             if isinstance(v, list):
                 if not all(isinstance(x, valid_types) for x in v):
-                    raise ValueError("message 'data' block contains invalid data type")
+                    type_set = set([type(x) for x in v])
+                    invalid_types = type_set.difference(valid_types)
+                    raise TypeError("message 'data' block contains invalid data" +
+                                    f"types: {invalid_types}")
+
             # single sample check
             else:
                 if not isinstance(v, valid_types):
-                    raise ValueError("message 'data' block contains invalid data type")
+                    invalid_type = type(v)
+                    raise TypeError("message 'data' block contains invalid " +
+                                    f"data type: {invalid_type}")

--- a/tests/test_ocs_feed.py
+++ b/tests/test_ocs_feed.py
@@ -63,12 +63,12 @@ class TestPublishMessage:
             }
         }
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             test_feed.publish_message(test_message)
 
     def test_str_multi_sample_input(self):
-        """Passing a string, even just one within a list, should cause an error
-        upon publishing.
+        """Passing multiple points, including multiple invalid datatypes,
+        should cause a TypeError upon publishing.
 
         """
         mock_agent = MagicMock()
@@ -76,14 +76,14 @@ class TestPublishMessage:
 
         test_message = {
             'block_name': 'test',
-            'timestamps': [time.time(), time.time()+1],
+            'timestamps': [time.time(), time.time()+1, time.time()+2],
             'data': {
-                'key1': [1., 3.4],
-                'key2': [10., 'string']
+                'key1': [1., 3.4, 4.3],
+                'key2': [10., 'string', None]
             }
         }
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             test_feed.publish_message(test_message)
 
 

--- a/tests/test_ocs_feed.py
+++ b/tests/test_ocs_feed.py
@@ -1,4 +1,52 @@
+import time
+from unittest.mock import MagicMock
+
+import pytest
 from ocs import ocs_feed
+
+
+# ocs_feed.Feed
+class TestPublishMessage:
+    """Test ocs_feed.Feed.publish_message().
+
+    """
+    def test_valid_input(self):
+        """We should be able to pass ints and floats to a feed.
+
+        """
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        test_message = {
+            'block_name': 'test',
+            'timestamps': [time.time(), time.time()+1],
+            'data': {
+                'key1': [1., 2.],
+                'key2': [10, 5]
+            }
+        }
+
+        test_feed.publish_message(test_message)
+
+    def test_str_input(self):
+        """Passing a string, even just one, should cause an error upon
+        publishing.
+
+        """
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        test_message = {
+            'block_name': 'test',
+            'timestamps': [time.time(), time.time()+1],
+            'data': {
+                'key1': [1., 3.4],
+                'key2': [10., 'string']
+            }
+        }
+
+        with pytest.raises(ValueError):
+            test_feed.publish_message(test_message)
 
 
 # ocs_feed.Block

--- a/tests/test_ocs_feed.py
+++ b/tests/test_ocs_feed.py
@@ -11,7 +11,7 @@ class TestPublishMessage:
 
     """
     def test_valid_single_sample_input(self):
-        """We should be able to pass ints and floats to a feed.
+        """We should be able to pass single ints and floats to a feed.
 
         """
         mock_agent = MagicMock()
@@ -29,7 +29,7 @@ class TestPublishMessage:
         test_feed.publish_message(test_message)
 
     def test_valid_multi_sample_input(self):
-        """We should be able to pass ints and floats to a feed.
+        """We should be able to pass lists of ints and floats to a feed.
 
         """
         mock_agent = MagicMock()
@@ -46,9 +46,29 @@ class TestPublishMessage:
 
         test_feed.publish_message(test_message)
 
-    def test_str_multi_sample_input(self):
+    def test_str_single_sample_input(self):
         """Passing a string, even just one, should cause an error upon
         publishing.
+
+        """
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        test_message = {
+            'block_name': 'test',
+            'timestamp': time.time(),
+            'data': {
+                'key1': 1.,
+                'key2': 'string',
+            }
+        }
+
+        with pytest.raises(ValueError):
+            test_feed.publish_message(test_message)
+
+    def test_str_multi_sample_input(self):
+        """Passing a string, even just one within a list, should cause an error
+        upon publishing.
 
         """
         mock_agent = MagicMock()

--- a/tests/test_ocs_feed.py
+++ b/tests/test_ocs_feed.py
@@ -10,7 +10,25 @@ class TestPublishMessage:
     """Test ocs_feed.Feed.publish_message().
 
     """
-    def test_valid_input(self):
+    def test_valid_single_sample_input(self):
+        """We should be able to pass ints and floats to a feed.
+
+        """
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        test_message = {
+            'block_name': 'test',
+            'timestamp': time.time(),
+            'data': {
+                'key1': 1.,
+                'key2': 10,
+            }
+        }
+
+        test_feed.publish_message(test_message)
+
+    def test_valid_multi_sample_input(self):
         """We should be able to pass ints and floats to a feed.
 
         """
@@ -28,7 +46,7 @@ class TestPublishMessage:
 
         test_feed.publish_message(test_message)
 
-    def test_str_input(self):
+    def test_str_multi_sample_input(self):
         """Passing a string, even just one, should cause an error upon
         publishing.
 


### PR DESCRIPTION
This is related to #103 and fixes #105.

After we identified that strings were being accidentally passed from the Bluefors log Agent, and that doing so would cause the Aggregator to crash, we've been in need of a mechanism for verifying the data we're passing to an OCS Feed.

This commit PR is based on the aggregator-type-checking branch, since the automated testing depends on the work I did there, so likely that PR should be merged first. But either way, this adds the `ocs.ocs_feed.Feed.verify_message_data_type()` function, which checks the types of data contained in a message's 'data' dictionary.

We also add tests for known valid and invalid cases.

I'd like feedback on the `valid_types` list, is `(int, float)` inclusive enough?