### PR TITLE
Updates to g32influx script

### DIFF
--- a/bin/g32influx
+++ b/bin/g32influx
@@ -186,9 +186,16 @@ class DataLoader:
         filename : str
             Full path to file to publish.
 
+        Returns
+        -------
+        int
+            Return value from scanner.run()
+
         """
         scanner = SingleFileScanner(filename, self.influxclient)
-        scanner.run()
+        rval = scanner.run()
+
+        return rval
 
     def publish_all_files_to_influxdb(self):
         """Publish all files found in target to InfluxDB.
@@ -208,8 +215,11 @@ class DataLoader:
         to_publish = c.fetchall()
 
         for path, chksum in tqdm(to_publish, desc="All Files"):
-            self._publish_file(path)
-            c.execute("UPDATE g3files SET published=1 WHERE md5sum=?", (chksum, ))
+            rval = self._publish_file(path)
+            if rval == 0:
+                c.execute("UPDATE g3files SET published=1 WHERE md5sum=?", (chksum, ))
+            else:
+                c.execute("UPDATE g3files SET published=? WHERE md5sum=?", (rval, chksum))
             self.sqliteconn.commit()
 
     def run(self):
@@ -318,8 +328,15 @@ class SingleFileScanner:
             influxdb.write_points(). Defaults to 10,000, which seems
             reasonable.
 
+        Returns
+        -------
+        int
+            0 if good, 2 if an excpetion occurred during publishing
+
         """
+        return_value = 0
         basename = os.path.basename(self.file)
+
         for field in tqdm(self.fields, desc=f"{basename} Fields"):
             payload = self.format_field(field)
             # print(f"publishing {field}...")
@@ -328,12 +345,15 @@ class SingleFileScanner:
             except InfluxDBClientError as e:
                 print(f"client error, likely a type error: {e}")
                 print(f"payload: {payload}")
+                return_value = 2
+
+        return return_value
 
     def run(self):
         self.scan_file()
-        self.publish_file()
+        pub_ret = self.publish_file()
 
-        return 0
+        return pub_ret
 
 
 def main():

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -364,6 +364,8 @@ def main():
     parser.add_argument('port', help='InfluxDB port.')
     parser.add_argument('--log', '-l', default='WARNING',
                         help='Set loglevel.')
+    parser.add_argument('--logfile', '-f', default='g32influx.log',
+                        help='Set the logfile.')
     # parser.add_argument('--docker', '-d', action='store_true',
     #                     help='Force use of docker, even if so3g is installed.')
     args = parser.parse_args()
@@ -372,7 +374,7 @@ def main():
     numeric_level = getattr(logging, args.log.upper(), None)
     if not isinstance(numeric_level, int):
         raise ValueError('Invalid log level: %s' % loglevel)
-    logging.basicConfig(filename='g32influx.log', level=numeric_level)
+    logging.basicConfig(filename=args.logfile, level=numeric_level)
 
     dl = DataLoader(args.target, host=args.host, port=args.port)
     dl.run()

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -7,6 +7,7 @@ import hashlib
 import datetime
 import sqlite3
 import argparse
+import logging
 
 from tqdm import tqdm
 
@@ -343,8 +344,8 @@ class SingleFileScanner:
             try:
                 self.client.write_points(payload, batch_size=batch_size)
             except InfluxDBClientError as e:
-                print(f"client error, likely a type error: {e}")
-                print(f"payload: {payload}")
+                logging.error(f"client error, likely a type error: {e}")
+                logging.debug(f"payload: {payload}")
                 return_value = 2
 
         return return_value
@@ -361,9 +362,17 @@ def main():
     parser.add_argument('target', help='File or directory to scan.')
     parser.add_argument('host', help='InfluxDB host.')
     parser.add_argument('port', help='InfluxDB port.')
+    parser.add_argument('--log', '-l',
+                        help='Set loglevel.')
     # parser.add_argument('--docker', '-d', action='store_true',
     #                     help='Force use of docker, even if so3g is installed.')
     args = parser.parse_args()
+
+    # Logging Configuration
+    numeric_level = getattr(logging, args.log.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError('Invalid log level: %s' % loglevel)
+    logging.basicConfig(level=numeric_level)
 
     dl = DataLoader(args.target, host=args.host, port=args.port)
     dl.run()

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -296,6 +296,7 @@ class SingleFileScanner:
 
         """
         t, x = self.cat.simple(field)
+        logging.debug("field:", field)
         agent_address, feed_and_field = field.split(".feeds.")
         feed_tag, field = feed_and_field.split(".")
 

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -322,11 +322,17 @@ class SingleFileScanner:
         for field in tqdm(self.fields, desc=f"{basename} Fields"):
             payload = self.format_field(field)
             # print(f"publishing {field}...")
-            self.client.write_points(payload, batch_size=batch_size)
+            try:
+                self.client.write_points(payload, batch_size=batch_size)
+            except InfluxDBClientError as e:
+                print(f"client error, likely a type error: {e}")
+                print(f"payload: {payload}")
 
     def run(self):
         self.scan_file()
         self.publish_file()
+
+        return 0
 
 
 def main():

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -234,6 +234,7 @@ class SingleFileScanner:
         for later processing.
 
         """
+        logging.debug("Scanning %s." % self.path)
         self.hkas.process_file(self.path)
         self.cat = self.hkas.finalize()
         self.fields, self.timelines = self.cat.get_fields()
@@ -342,7 +343,7 @@ class SingleFileScanner:
         Returns
         -------
         int
-            0 if good, 2 if an excpetion occurred during publishing
+            0 if good, 2 if an exception occurred during publishing
         """
         return_value = 0
         self._influx_log("started")
@@ -373,7 +374,12 @@ class SingleFileScanner:
         return return_value
 
     def run(self):
-        self.scan_file()
+        try:
+            self.scan_file()
+        except:
+            logging.error("Unable to read %s, likely due to old sog3 format."\
+                          % self.basename)
+            return 2
         pub_ret = self.publish_file()
 
         return pub_ret

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -112,7 +112,7 @@ class DataLoader:
         Connection to the sqlite3 database
 
     """
-    def __init__(self, target, host='localhost', port=8086):
+    def __init__(self, target, host='localhost', port=8086, startdate="1970-01-01", enddate="2070-01-01"):
         self.influxclient = InfluxDBClient(host=host, port=port)
         self._init_influxdb()
 
@@ -121,6 +121,11 @@ class DataLoader:
 
         self.target = target
         self._file_list = _build_file_list(target)
+
+        self.startdate = datetime.datetime.strptime(startdate, "%Y-%m-%d")
+        self.enddate = datetime.datetime.strptime(end, "%Y-%m-%d")
+
+        self._file_list = _reduce_filelist_by_date()
 
     def _init_influxdb(self, db='ocs_feeds'):
         """Initializes InfluxDB after connection.
@@ -155,6 +160,22 @@ class DataLoader:
 
         self.sqliteconn.commit()
         c.close()
+
+    def _reduce_filelist_by_date(self):
+        """If the user has passed in optional start and end date parameters,
+        limit the filelist by removing files that fall outside of the given range.
+
+        """
+        new_list = []
+        for f in self._file_list:
+            date_string = os.path.basename(f).strip(".g3")
+            dt = datetime.datetime.strptime(date_string, "%Y-%m-%d-%H-%M-%S")
+            if dt > self.startdate and dt < self.enddate:
+                new_list.append(f)
+            else:
+                logging.debug(f"Removing {f} from filelist, outside of start/end dates.")
+
+        return new_list
 
     def check_filelist_against_sqlite(self):
         """Compares file list to sqlite database. Insert files if they aren't
@@ -343,7 +364,7 @@ class SingleFileScanner:
             try:
                 payload = self.format_field(field)
             except ValueError:
-                logging.error("Unable to format payload properly, possibly" +
+                logging.error("Unable to format payload properly, possibly " +
                               "trying to process old .g3 file format...")
                 return 2
             # print(f"publishing {field}...")
@@ -369,6 +390,10 @@ def main():
     parser.add_argument('target', help='File or directory to scan.')
     parser.add_argument('host', help='InfluxDB host.')
     parser.add_argument('port', help='InfluxDB port.')
+    parser.add_argument('--start', default='1970-01-01',
+                        help='Set startdate, cutting all files that start before this date.')
+    parser.add_argument('--end', default='2070-01-01',
+                        help='Set enddate, cutting all files that start after this date.')
     parser.add_argument('--log', '-l', default='WARNING',
                         help='Set loglevel.')
     parser.add_argument('--logfile', '-f', default='g32influx.log',
@@ -383,7 +408,7 @@ def main():
         raise ValueError('Invalid log level: %s' % loglevel)
     logging.basicConfig(filename=args.logfile, level=numeric_level)
 
-    dl = DataLoader(args.target, host=args.host, port=args.port)
+    dl = DataLoader(args.target, host=args.host, port=args.port, startdate=args.start, enddate=args.end)
     dl.run()
 
 

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -344,6 +344,7 @@ class SingleFileScanner:
             try:
                 self.client.write_points(payload, batch_size=batch_size)
             except InfluxDBClientError as e:
+                logging.error(f"ERROR in {self.file}")
                 logging.error(f"client error, likely a type error: {e}")
                 logging.debug(f"payload: {payload}")
                 return_value = 2

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -168,8 +168,8 @@ class DataLoader:
         """
         new_list = []
         for f in self._file_list:
-            date_string = os.path.basename(f).strip(".g3")
-            dt = datetime.datetime.strptime(date_string, "%Y-%m-%d-%H-%M-%S")
+            date_string = os.path.basename(f)
+            dt = datetime.datetime.strptime(date_string, "%Y-%m-%d-%H-%M-%S.g3")
             if dt > self.startdate and dt < self.enddate:
                 new_list.append(f)
             else:

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -123,7 +123,7 @@ class DataLoader:
         self._file_list = _build_file_list(target)
 
         self.startdate = datetime.datetime.strptime(startdate, "%Y-%m-%d")
-        self.enddate = datetime.datetime.strptime(end, "%Y-%m-%d")
+        self.enddate = datetime.datetime.strptime(enddate, "%Y-%m-%d")
 
         self._file_list = _reduce_filelist_by_date()
 

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -362,7 +362,7 @@ def main():
     parser.add_argument('target', help='File or directory to scan.')
     parser.add_argument('host', help='InfluxDB host.')
     parser.add_argument('port', help='InfluxDB port.')
-    parser.add_argument('--log', '-l',
+    parser.add_argument('--log', '-l', default='WARNING',
                         help='Set loglevel.')
     # parser.add_argument('--docker', '-d', action='store_true',
     #                     help='Force use of docker, even if so3g is installed.')

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -214,8 +214,12 @@ class DataLoader:
             Return value from scanner.run()
 
         """
-        scanner = SingleFileScanner(filename, self.influxclient)
-        rval = scanner.run()
+        try:
+            scanner = SingleFileScanner(filename, self.influxclient)
+            rval = scanner.run()
+        except RuntimeError:
+            logging.error("Unable to process file, skipping.")
+            return 2
 
         return rval
 
@@ -296,12 +300,8 @@ class SingleFileScanner:
         for later processing.
 
         """
-        try:
-            self.hkas.process_file(self.file)
-        except RuntimeError:
-            logging.error("Unable to process file, skipping.")
+        self.hkas.process_file(self.file)
 
-            return 2
         self.cat = self.hkas.finalize()
         # print("Getting fields")
         self.fields, self.timelines = self.cat.get_fields()
@@ -386,10 +386,10 @@ class SingleFileScanner:
         return return_value
 
     def run(self):
-        scan_ret = self.scan_file()
+        self.scan_file()
         pub_ret = self.publish_file()
 
-        return pub_ret + scan_ret
+        return pub_ret
 
 
 def main():

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -1,0 +1,275 @@
+#!/usr/bin/python3
+
+# Read from .g3 file and insert into InfluxDB.
+
+import os
+import hashlib
+import datetime
+import sqlite3
+
+from progress.bar import Bar
+
+from influxdb import InfluxDBClient
+
+from ocs.checkdata import _build_file_list
+from so3g import hk
+
+
+def timestamp2influxtime(time):
+    """Convert timestamp for influx.
+
+    Parameters
+    ----------
+    time : float
+        ctime timestamp
+
+    Returns
+    -------
+    str
+        Time formatted for insertion to influxDB
+
+    """
+    t_dt = datetime.datetime.fromtimestamp(time)
+    return t_dt.strftime("%Y-%m-%dT%H:%M:%S.%f")
+
+
+def connect_to_sqlite(path=None, db_file=".g32influx.db"):
+    """Tries to determine OCS_SITE_CONFIG location from environment variables.
+    Uses current directory to store sqliteDB if unset.
+
+    Parameters
+    ----------
+    path : str
+        Path to store db in. If None, OCS_SITE_CONFIG is used. If
+        OCS_SITE_CONFIG is unset, the current directory is used.
+    db_file : str
+        basename for sqlite file
+
+    Returns
+    -------
+    sqlite3.Connection
+        Connection to sqlite3 database
+
+    """
+    if path is None:
+        path = os.environ.get("OCS_SITE_CONFIG", "./")
+    full_path = os.path.join(path, db_file)
+    conn = sqlite3.connect(full_path)
+
+    return conn
+
+
+def _md5sum(filename, blocksize=65536):
+    """Compute md5sum of a file.
+
+    References
+    ----------
+    - https://stackoverflow.com/questions/3431825/generating-an-md5-checksum-of-a-file
+
+    Parameters
+    ----------
+    filename : str
+        Full path to file for which we want the md5
+    blocksize : int
+        blocksize we want to read the file in chunks of to avoid fitting the
+        whole file into memory. Defaults to 65536
+
+    Returns
+    -------
+    str
+        Hex string representing the md5sum of the file
+
+    """
+    hash_ = hashlib.md5()
+    with open(filename, "rb") as f:
+        for block in iter(lambda: f.read(blocksize), b""):
+            hash_.update(block)
+    return hash_.hexdigest()
+
+
+class DataLoader:
+    """Check data for latest feeds and fields.
+
+    Parameters
+    ----------
+    target : str
+        File or directory to scan.
+    host : str
+        InfluxDB host address
+    port : int
+        InfluxDB port
+
+    Attributes
+    ----------
+    hkas : so3g.hk.HKArchiveScanner
+        HKArchiveScanner for reading in the data
+    cat :
+        Finalized HKArchiveScanner
+    target : str
+        File or directory to scan.
+    verbose : bool
+        Verbose output flag
+
+    """
+    def __init__(self, target, host='localhost', port=8086):
+        self.influxclient = InfluxDBClient(host=host, port=port)
+        self._init_influxdb()
+
+        self.sqliteconn = connect_to_sqlite()
+        self._init_sqlitedb()
+
+        self.target = target
+        self._file_list = _build_file_list(target)
+
+    def _init_influxdb(self, db='ocs_feeds'):
+        """Initializes influxDB after connection.
+
+        Gets a list of existing databases within InfluxDB, creates db if it
+        doesn't exist (defaults to 'ocs_feeds'), and switches the client to
+        that db.
+
+        """
+        db_list = self.influxclient.get_list_database()
+        db_names = [x['name'] for x in db_list]
+        
+        if 'ocs_feeds' not in db_names:
+            print("ocs_feeds DB doesn't exist, creating DB")
+            self.influxclient.create_database('ocs_feeds')
+        
+        self.influxclient.switch_database('ocs_feeds')
+
+    def _init_sqlitedb(self):
+        """Initialize the sqlitedb after connection.
+
+        We call our table 'g3files'.
+
+        """
+        c = self.sqliteconn.cursor()
+        c.execute("CREATE TABLE IF NOT EXISTS g3files (path TEXT UNIQUE, md5sum TEXT, published INTEGER)")
+
+        self.sqliteconn.commit()
+        c.close()
+
+    def check_filelist_against_sqlite(self):
+        """Compares file list to sqlite database. Insert files if they aren't
+        present. Updates paths if files found have moved since last seen.
+
+        """
+        c = self.sqliteconn.cursor()
+
+        for f in self._file_list:
+            md5 = _md5sum(f)
+            c.execute("SELECT * from g3files WHERE md5sum=?", (md5, ))
+            result = c.fetchone()
+            if result is None:
+                print(f"No match for {md5}, inserting into SQLiteDB")
+                c.execute("INSERT INTO g3files VALUES (?, ?, 0)", (f, md5))
+                self.sqliteconn.commit()
+            elif result[0] != f:
+                print(f"Path changed for hash {md5}, updating path to {f}")
+                c.execute("UPDATE g3files SET path=? WHERE md5sum=?", (f, md5))
+                self.sqliteconn.commit()
+
+        c.close()
+
+    def _publish_file(self, filename):
+        """Publish the contents of a .g3 file to InfluxDB."""
+        scanner = SingleFileScanner(filename, self.influxclient)
+        scanner.run()
+
+    def publish_all_files_to_influxdb(self):
+        """Publish all files found in target to InfluxDB.
+
+        Will check if file has been published already, if not, will scan and
+        publish contents, then mark as published in sqliteDB.
+
+        """
+        c = self.sqliteconn.cursor()
+
+        c.execute("SELECT path, md5sum from g3files WHERE published=0")
+        to_publish = c.fetchall()
+
+        _bar = Bar('Publishing', max=len(to_publish))
+        for path, chksum in to_publish:
+            self._publish_file(path)
+            c.execute("UPDATE g3files SET published=1 WHERE md5sum=?", (chksum, ))
+            self.sqliteconn.commit()
+            _bar.next()
+        _bar.finish()
+
+    def run(self):
+        self.check_filelist_against_sqlite()
+        self.publish_all_files_to_influxdb()
+
+
+class SingleFileScanner:
+    def __init__(self, filename, influxdb):
+        self.file = filename
+        self.client = influxdb
+
+        self.hkas = hk.HKArchiveScanner()
+        self.cat = None
+
+        self.fields = None
+        self.timelines = None
+
+    def scan_file(self):
+        """Scan the file with the HKArchiveScanner and get the fields
+        for later processing.
+
+        """
+        self.hkas.process_file(self.file)
+        self.cat = self.hkas.finalize()
+        print("Getting fields")
+        self.fields, self.timelines = self.cat.get_fields()
+        print("fields acquired")
+
+    def format_field(self, field):
+        """Format a given field for publishing to the database.
+
+        Parameters
+        ----------
+        field : str
+            Field to publish data from, will query the finalized HKArchive
+        batch_size : int
+            Number of points to publish per write, passed to influxdb.write_points()
+
+        """
+        t, x = self.cat.simple(field)
+        agent_address, feed_and_field = field.split(".feeds.")
+        feed_tag, field = feed_and_field.split(".")
+
+        json_body = []
+
+        for _x, _t in zip(x, t):
+            fields = {field: _x}
+            json_body.append(
+                {
+                    "measurement": agent_address,
+                    "time": timestamp2influxtime(_t),
+                    "fields": fields,
+                    "tags" : {
+                        "feed": feed_tag
+                    }
+
+                }
+            )
+
+        #print("payload: {}".format(json_body))
+
+        return json_body
+
+    def publish_file(self, batch_size=10000):
+        for field in self.fields:
+            payload = self.format_field(field)
+            print(f"publishing {field}...")
+            self.client.write_points(payload, batch_size=batch_size)
+
+    def run(self):
+        self.scan_file()
+        self.publish_file()
+
+dl = DataLoader('/home/koopman/data/15760/')
+dl.run()
+
+#payload = dl.publish_field(list(dl.fields)[0])

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -332,11 +332,13 @@ class SingleFileScanner:
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('target', help='File or directory to scan.')
+    parser.add_argument('host', help='InfluxDB host.')
+    parser.add_argument('port', help='InfluxDB port.')
     # parser.add_argument('--docker', '-d', action='store_true',
     #                     help='Force use of docker, even if so3g is installed.')
     args = parser.parse_args()
 
-    dl = DataLoader(args.target)
+    dl = DataLoader(args.target, host=args.host, port=args.port)
     dl.run()
 
 

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -280,8 +280,8 @@ class SingleFileScanner:
         msg : str
             Any message (e.g., an error message) to log.
         """
-        l = "%s,dir=%s,file=%s,md5sum=%s status=\"%s\"" %\
-            (_LOG_MEASUREMENT, self.dir, self.basename, self.md5sum, status)
+        l = "%s,status=%s dir=\"%s\",file=\"%s\",md5sum=\"%s\"" %\
+            (_LOG_MEASUREMENT, status, self.dir, self.basename, self.md5sum)
         if msg:
             l += ",msg=\"%s\"" % msg
         try:

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -340,7 +340,12 @@ class SingleFileScanner:
         basename = os.path.basename(self.file)
 
         for field in tqdm(self.fields, desc=f"{basename} Fields"):
-            payload = self.format_field(field)
+            try:
+                payload = self.format_field(field)
+            except ValueError:
+                logging.error("Unable to format payload properly, possibly" +
+                              "trying to process old .g3 file format...")
+                return 2
             # print(f"publishing {field}...")
             try:
                 self.client.write_points(payload, batch_size=batch_size)

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -125,7 +125,7 @@ class DataLoader:
         self.startdate = datetime.datetime.strptime(startdate, "%Y-%m-%d")
         self.enddate = datetime.datetime.strptime(enddate, "%Y-%m-%d")
 
-        self._file_list = _reduce_filelist_by_date()
+        self._file_list = self._reduce_filelist_by_date()
 
     def _init_influxdb(self, db='ocs_feeds'):
         """Initializes InfluxDB after connection.

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -11,6 +11,7 @@ import argparse
 from tqdm import tqdm
 
 from influxdb import InfluxDBClient
+from influxdb.exceptions import InfluxDBClientError
 
 from ocs.checkdata import _build_file_list
 from so3g import hk

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -1,13 +1,13 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Read from .g3 file and insert into InfluxDB.
 
-import os
-import hashlib
-import datetime
-import sqlite3
 import argparse
+import datetime
+import hashlib
 import logging
+import numpy as np
+import os
 
 from tqdm import tqdm
 
@@ -17,52 +17,15 @@ from influxdb.exceptions import InfluxDBClientError
 from ocs.checkdata import _build_file_list
 from so3g import hk
 
+# Accepted formats for parsing the g3 file datetimes.
+_G3_DATETIME_FMT = ["%Y-%m-%d-%H-%M-%S.g3",
+                    "%Y-%m-%d_T_%H:%M:%S.g3"]
 
-def timestamp2influxtime(time):
-    """Convert timestamp for influx.
+# Measurement name in influx DB for logging which files have been/are being
+# transfered over.
+_LOG_MEASUREMENT = ".g32influx.log"
 
-    Parameters
-    ----------
-    time : float
-        ctime timestamp
-
-    Returns
-    -------
-    str
-        Time formatted for insertion to influxDB
-
-    """
-    t_dt = datetime.datetime.fromtimestamp(time)
-    return t_dt.strftime("%Y-%m-%dT%H:%M:%S.%f")
-
-
-def connect_to_sqlite(path=None, db_file=".g32influx.db"):
-    """Tries to determine OCS_SITE_CONFIG location from environment variables.
-    Uses current directory to store sqliteDB if unset.
-
-    Parameters
-    ----------
-    path : str
-        Path to store db in. If None, OCS_SITE_CONFIG is used. If
-        OCS_SITE_CONFIG is unset, the current directory is used.
-    db_file : str
-        basename for sqlite file
-
-    Returns
-    -------
-    sqlite3.Connection
-        Connection to sqlite3 database
-
-    """
-    if path is None:
-        path = os.environ.get("OCS_SITE_CONFIG", "./")
-    full_path = os.path.join(path, db_file)
-    conn = sqlite3.connect(full_path)
-
-    return conn
-
-
-def _md5sum(filename, blocksize=65536):
+def _md5sum(path, blocksize=65536):
     """Compute md5sum of a file.
 
     References
@@ -71,7 +34,7 @@ def _md5sum(filename, blocksize=65536):
 
     Parameters
     ----------
-    filename : str
+    path : str
         Full path to file for which we want the md5
     blocksize : int
         blocksize we want to read the file in chunks of to avoid fitting the
@@ -84,11 +47,40 @@ def _md5sum(filename, blocksize=65536):
 
     """
     hash_ = hashlib.md5()
-    with open(filename, "rb") as f:
+    with open(path, "rb") as f:
         for block in iter(lambda: f.read(blocksize), b""):
             hash_.update(block)
     return hash_.hexdigest()
 
+
+def _get_file_list(target):
+    """Build list of files to scan.
+    This is based on ocs.checkdata._build_file_list, but copied here so that if
+    this script is removed from the ocs repo we don't have to import the latter
+    just for one method.
+
+    Parameters
+    ----------
+    target : str
+        File or directory to scan.
+
+    Returns
+    -------
+    list
+        List of full paths to files for scanning.
+
+    """
+    _file_list = []
+    if os.path.isfile(target):
+        _file_list.append(target)
+    elif os.path.isdir(target):
+        a = os.walk(target)
+        for root, _, _file in a:
+            for g3 in _file:
+                if g3[-2:] == "g3":
+                    _file_list.append(os.path.join(root, g3))
+
+    return _file_list
 
 class DataLoader:
     """Load data from .g3 file into an InfluxDB instance.
@@ -106,24 +98,20 @@ class DataLoader:
     ----------
     target : str
         File or directory to scan.
-    influxclient : influxdb.InfluxDBClient
+    db : influxdb.InfluxDBClient
         Connection to the InfluxDB, used to publish data to the database.
-    sqliteconn : sqlite3.Connection
-        Connection to the sqlite3 database
-
     """
-    def __init__(self, target, host='localhost', port=8086, startdate="1970-01-01", enddate="2070-01-01"):
-        self.influxclient = InfluxDBClient(host=host, port=port)
+    def __init__(self, target, host='localhost', port=8086,
+                 startdate="1970-01-01", enddate="2070-01-01", force=False):
+        self.db = InfluxDBClient(host=host, port=port)
         self._init_influxdb()
 
-        self.sqliteconn = connect_to_sqlite()
-        self._init_sqlitedb()
-
-        self.target = target
-        self._file_list = _build_file_list(target)
+        self.target = os.path.abspath(target)
+        self._file_list = _get_file_list(self.target)
 
         self.startdate = datetime.datetime.strptime(startdate, "%Y-%m-%d")
         self.enddate = datetime.datetime.strptime(enddate, "%Y-%m-%d")
+        self.force = force
 
         self._file_list = self._reduce_filelist_by_date()
 
@@ -140,117 +128,57 @@ class DataLoader:
             Name for the database, default to 'ocs_feeds'.
 
         """
-        db_list = self.influxclient.get_list_database()
+        db_list = self.db.get_list_database()
         db_names = [x['name'] for x in db_list]
 
         if 'ocs_feeds' not in db_names:
             logging.info("ocs_feeds DB doesn't exist, creating DB")
-            self.influxclient.create_database(db)
+            self.db.create_database(db)
 
-        self.influxclient.switch_database(db)
-
-    def _init_sqlitedb(self):
-        """Initialize the sqlitedb after connection.
-
-        We call our table 'g3files'. You probably don't need to change this.
-
-        """
-        c = self.sqliteconn.cursor()
-        c.execute("CREATE TABLE IF NOT EXISTS g3files (path TEXT UNIQUE, md5sum TEXT, published INTEGER)")
-
-        self.sqliteconn.commit()
-        c.close()
+        self.db.switch_database(db)
 
     def _reduce_filelist_by_date(self):
         """If the user has passed in optional start and end date parameters,
-        limit the filelist by removing files that fall outside of the given range.
-
+        limit the filelist by removing files that fall outside of the given
+        range.
         """
         new_list = []
         for f in self._file_list:
             date_string = os.path.basename(f)
-            dt = datetime.datetime.strptime(date_string, "%Y-%m-%d-%H-%M-%S.g3")
-            if dt > self.startdate and dt < self.enddate:
+            dt = None
+            for fmt in _G3_DATETIME_FMT: 
+                try:
+                    dt = datetime.datetime.strptime(date_string, fmt)
+                except ValueError:
+                    pass
+            if dt == None:
+                logging.error(f"Removing {f} from file list: bad filename "\
+                               "format.")
+            elif dt > self.startdate and dt < self.enddate:
                 new_list.append(f)
             else:
-                logging.debug(f"Removing {f} from filelist, outside of start/end dates.")
+                logging.info(f"Removing {f} from file list: "\
+                              "outside of start/end dates.")
 
         return new_list
 
-    def check_filelist_against_sqlite(self):
-        """Compares file list to sqlite database. Insert files if they aren't
-        present. Updates paths if files found have moved since they were last
-        seen.
-
-        """
-        c = self.sqliteconn.cursor()
-
-        for f in self._file_list:
-            md5 = _md5sum(f)
-            c.execute("SELECT * from g3files WHERE md5sum=?", (md5, ))
-            result = c.fetchone()
-            if result is None:
-                logging.info(f"No match for {md5}, inserting into SQLiteDB")
-                c.execute("INSERT INTO g3files VALUES (?, ?, 0)", (f, md5))
-                self.sqliteconn.commit()
-            elif result[0] != f:
-                logging.info(f"Path changed for hash {md5}, updating path to {f}")
-                c.execute("UPDATE g3files SET path=? WHERE md5sum=?", (f, md5))
-                self.sqliteconn.commit()
-
-        c.close()
-
-    def _publish_file(self, filename):
-        """Publish the contents of a .g3 file to InfluxDB.
-
-        Parameters
-        ----------
-        filename : str
-            Full path to file to publish.
-
-        Returns
-        -------
-        int
-            Return value from scanner.run()
-
-        """
-        try:
-            scanner = SingleFileScanner(filename, self.influxclient)
-            rval = scanner.run()
-        except RuntimeError:
-            logging.error("Unable to process file, skipping.")
-            return 2
-
-        return rval
-
-    def publish_all_files_to_influxdb(self):
-        """Publish all files found in target to InfluxDB.
-
-        Will build list of files not already published from sqlite database,
-        scan and publish contents, then mark as published in sqliteDB.
-
-        This has the side-effect that it will publish files previously entered
-        into the database, even if not in the target list for this particular call, say
-        if a previous upload was cancelled. This should probably be addressed in
-        future versions.
-
-        """
-        c = self.sqliteconn.cursor()
-
-        c.execute("SELECT path, md5sum from g3files WHERE published=0")
-        to_publish = c.fetchall()
-
-        for path, chksum in tqdm(to_publish, desc="All Files"):
-            rval = self._publish_file(path)
-            if rval == 0:
-                c.execute("UPDATE g3files SET published=1 WHERE md5sum=?", (chksum, ))
-            else:
-                c.execute("UPDATE g3files SET published=? WHERE md5sum=?", (rval, chksum))
-            self.sqliteconn.commit()
-
     def run(self):
-        self.check_filelist_against_sqlite()
-        self.publish_all_files_to_influxdb()
+        for path in self._file_list:
+            md5sum = _md5sum(path)
+            fname = os.path.basename(path)
+            res = self.db.query("SELECT * FROM \"%s\" WHERE "\
+                                "md5sum = '%s' AND status = 'completed';" %\
+                                (_LOG_MEASUREMENT, md5sum))
+            if len(res.items()) and not self.force:
+                logging.info("Skipping %s: already completed." % fname)
+            else:
+                if len(res.items()):
+                    logging.info("Rewriting %s due to `--force`." % fname)
+                try:
+                     scanner = SingleFileScanner(path, self.db, md5sum=md5sum)
+                     scanner.run()
+                except RuntimeError:
+                     logging.error("Unable to process file, skipping.")
 
 
 class SingleFileScanner:
@@ -264,16 +192,20 @@ class SingleFileScanner:
 
     Parameters
     ----------
-    filename : str
+    path : str
         Full path to file for scanning
-    influxdb : influxdb.InfluxDBClient
+    md5sum : str
+        Computed md5sum for file. (If `None` is passed, it will be computed.)
+    db : influxdb.InfluxDBClient
         Connection to the InfluxDB, used to publish data to the database.
 
     Attributes
     ----------
-    file : str
+    path : str
         Full path to file for scanning
-    client : influxdb.InfluxDBClient
+    md5sum : str
+        The md5sum of the file.
+    db : influxdb.InfluxDBClient
         Connection to the InfluxDB, used to publish data to the database.
     hkas : so3g.hk.HKArchiveScanner
         HKArchiveScanner for reading in the data
@@ -285,9 +217,11 @@ class SingleFileScanner:
         Timelines within the file as returned by cat.get_fields()
 
     """
-    def __init__(self, filename, influxdb):
-        self.file = filename
-        self.client = influxdb
+    def __init__(self, path, db, md5sum=None):
+        self.path = path
+        self.dir, self.basename = os.path.split(path)
+        self.md5sum = md5sum if md5sum is not None else _md5sum(path)
+        self.db = db
 
         self.hkas = hk.HKArchiveScanner()
         self.cat = None
@@ -300,17 +234,16 @@ class SingleFileScanner:
         for later processing.
 
         """
-        self.hkas.process_file(self.file)
-
+        self.hkas.process_file(self.path)
         self.cat = self.hkas.finalize()
-        # print("Getting fields")
         self.fields, self.timelines = self.cat.get_fields()
-        # print("fields acquired")
 
         return 0
 
     def format_field(self, field):
         """Format a given field for publishing to the database.
+        Deprecated: formating field by field is significantly slower than doing
+        it by timeline: see `format_timeline()`.
 
         Parameters
         ----------
@@ -325,64 +258,118 @@ class SingleFileScanner:
         """
         t, x = self.cat.simple(field)
         logging.debug("field:", field)
-        agent_address, feed_and_field = field.split(".feeds.")
-        feed_tag, field = feed_and_field.split(".")
+        agent_address = field.split(".feeds.")[0].replace(" ", "\\ ")
+        ff = field.split(".feeds.")[1]
+        feed_tag = ff.split(".")[0].replace(" ", "\\ ")
+        field = ff.split(".")[1].replace(" ", "\\ ")
 
-        json_body = []
-
+        line = []
         for _x, _t in zip(x, t):
-            fields = {field: _x}
-            json_body.append(
-                {
-                    "measurement": agent_address,
-                    "time": timestamp2influxtime(_t),
-                    "fields": fields,
-                    "tags": {
-                        "feed": feed_tag
-                    }
+            line.append("%s,feed=%s %s=%s %d\n" % (agent_address, feed_tag,
+                                                   field, _x, _t * 1e9))
+        return line
 
-                }
-            )
+    def _influx_log(self, status, msg=None):
+        """Write a log message to influx about current file.
 
-        # print("payload: {}".format(json_body))
+        Parameters
+        ----------
+        status : str
+            The status to log.
+        msg : str
+            Any message (e.g., an error message) to log.
+        """
+        l = "%s,dir=%s,file=%s,md5sum=%s status=\"%s\"" %\
+            (_LOG_MEASUREMENT, self.dir, self.basename, self.md5sum, status)
+        if msg:
+            l += ",msg=\"%s\"" % msg
+        try:
+            self.db.write_points([l], protocol="line")
+        except InfluxDBClientError as e:
+            logging.error("Error writing log: %s." % e)
+ 
+    def format_timeline(self, timeline, name):
+        """Format a given timeline for publishing to the database.
 
-        return json_body
+        Parameters
+        ----------
+        field : str
+            Timeline to publish data from, will query the finalized HKArchive.
 
-    def publish_file(self, batch_size=10000):
+        Returns
+        -------
+        list
+            List of points, in line protocol, for writing to InfluxDB.
+        """
+        field = timeline["field"]
+        logging.debug("Timeline: %s" % name)
+
+        # Do some good, ol' fashioned parsing.
+        s = field[0].split(".feeds.")
+        agent_address = s[0].replace(" ", "\ ")
+        ff = field[0].split(".feeds.")[1]
+        feed_val = s[1].split(".")[0].replace(" ", "\ ")
+        field_tag = [f.split(".feeds.")[1].split(".")[1].replace(" ", "\ ") \
+                     for f in field]
+
+        # Get the data. Since all the fields belong to the same timeline, their
+        # timestamps are all the same object, which we can just grab from the 
+        # first element of returned array. Then we need to transpose the data 
+        # so that we can read it timestamp by timestamp.
+        raw_data = self.cat.simple(field)
+        t = raw_data[0][0]
+        data = np.transpose(np.stack([d[1] for d in raw_data]))
+
+        # Create the line output.
+        line = []
+        for _t, _data in zip(t, data):
+            flist = ",".join(["%s=%s" % (_f, _d) \
+                              for _f, _d in zip(field_tag, _data)])
+            line.append("%s,feed=%s,g3_md5sum=%s %s %d\n" %\
+                        (agent_address, feed_val, self.md5sum, flist, _t * 1e9))
+        return line
+
+    def publish_file(self, batch_size=100000):
         """Publish a files contents to InfluxDB.
 
         Parameters
         ----------
         batch_size : int
             Number of points to publish per write, passed to
-            influxdb.write_points(). Defaults to 10,000, which seems
+            influxdb.write_points(). Defaults to 100,000, which seems
             reasonable.
 
         Returns
         -------
         int
             0 if good, 2 if an excpetion occurred during publishing
-
         """
         return_value = 0
-        basename = os.path.basename(self.file)
+        self._influx_log("started")
 
-        for field in tqdm(self.fields, desc=f"{basename} Fields"):
+        for name, timeline in tqdm(self.timelines.items(),
+                                   desc=f"{self.basename} Timelines"):
             try:
-                payload = self.format_field(field)
+                payload = self.format_timeline(timeline, name)
             except ValueError:
                 logging.error("Unable to format payload properly, possibly " +
                               "trying to process old .g3 file format...")
+                self._influx_log("error", "unable to format payload")
+                self._influx_log("finished")
                 return 2
-            # print(f"publishing {field}...")
             try:
-                self.client.write_points(payload, batch_size=batch_size)
+                self.db.write_points(payload, batch_size=batch_size,
+                                     protocol="line")
             except InfluxDBClientError as e:
-                logging.error(f"ERROR in {self.file}")
+                logging.error(f"ERROR in {self.path}")
                 logging.error(f"client error, likely a type error: {e}")
                 logging.debug(f"payload: {payload}")
+                self._influx_log("error", "unable to write to influx")
                 return_value = 2
 
+        if not return_value:
+            self._influx_log("completed")
+        self._influx_log("finished")
         return return_value
 
     def run(self):
@@ -397,16 +384,22 @@ def main():
     parser.add_argument('target', help='File or directory to scan.')
     parser.add_argument('host', help='InfluxDB host.')
     parser.add_argument('port', help='InfluxDB port.')
-    parser.add_argument('--start', default='1970-01-01',
-                        help='Set startdate, cutting all files that start before this date.')
-    parser.add_argument('--end', default='2070-01-01',
-                        help='Set enddate, cutting all files that start after this date.')
+    parser.add_argument('--start', '-s', default='1970-01-01',
+                        help='Set startdate, cutting all files that start '\
+                             'before this date.')
+    parser.add_argument('--end', '-e', default='2070-01-01',
+                        help='Set enddate, cutting all files that start '\
+                        'after this date.')
     parser.add_argument('--log', '-l', default='WARNING',
                         help='Set loglevel.')
-    parser.add_argument('--logfile', '-f', default='g32influx.log',
+    parser.add_argument('--logfile', '-L', default='g32influx.log',
                         help='Set the logfile.')
+    parser.add_argument('--force', '-f', action='store_true',
+                        help='If a file has already been written to influx,'\
+                             'force a rewrite.')
     # parser.add_argument('--docker', '-d', action='store_true',
-    #                     help='Force use of docker, even if so3g is installed.')
+    #                     help='Force use of docker, even if so3g is \
+    #                            installed.')
     args = parser.parse_args()
 
     # Logging Configuration
@@ -415,7 +408,8 @@ def main():
         raise ValueError('Invalid log level: %s' % loglevel)
     logging.basicConfig(filename=args.logfile, level=numeric_level)
 
-    dl = DataLoader(args.target, host=args.host, port=args.port, startdate=args.start, enddate=args.end)
+    dl = DataLoader(args.target, host=args.host, port=args.port,
+                    startdate=args.start, enddate=args.end, force=args.force)
     dl.run()
 
 

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -6,8 +6,9 @@ import os
 import hashlib
 import datetime
 import sqlite3
+import argparse
 
-from progress.bar import Bar
+from tqdm import tqdm
 
 from influxdb import InfluxDBClient
 
@@ -88,7 +89,7 @@ def _md5sum(filename, blocksize=65536):
 
 
 class DataLoader:
-    """Check data for latest feeds and fields.
+    """Load data from .g3 file into an InfluxDB instance.
 
     Parameters
     ----------
@@ -101,14 +102,12 @@ class DataLoader:
 
     Attributes
     ----------
-    hkas : so3g.hk.HKArchiveScanner
-        HKArchiveScanner for reading in the data
-    cat :
-        Finalized HKArchiveScanner
     target : str
         File or directory to scan.
-    verbose : bool
-        Verbose output flag
+    influxclient : influxdb.InfluxDBClient
+        Connection to the InfluxDB, used to publish data to the database.
+    sqliteconn : sqlite3.Connection
+        Connection to the sqlite3 database
 
     """
     def __init__(self, target, host='localhost', port=8086):
@@ -122,26 +121,31 @@ class DataLoader:
         self._file_list = _build_file_list(target)
 
     def _init_influxdb(self, db='ocs_feeds'):
-        """Initializes influxDB after connection.
+        """Initializes InfluxDB after connection.
 
         Gets a list of existing databases within InfluxDB, creates db if it
         doesn't exist (defaults to 'ocs_feeds'), and switches the client to
         that db.
 
+        Parameters
+        ----------
+        db : str
+            Name for the database, default to 'ocs_feeds'.
+
         """
         db_list = self.influxclient.get_list_database()
         db_names = [x['name'] for x in db_list]
-        
+
         if 'ocs_feeds' not in db_names:
             print("ocs_feeds DB doesn't exist, creating DB")
-            self.influxclient.create_database('ocs_feeds')
-        
-        self.influxclient.switch_database('ocs_feeds')
+            self.influxclient.create_database(db)
+
+        self.influxclient.switch_database(db)
 
     def _init_sqlitedb(self):
         """Initialize the sqlitedb after connection.
 
-        We call our table 'g3files'.
+        We call our table 'g3files'. You probably don't need to change this.
 
         """
         c = self.sqliteconn.cursor()
@@ -152,7 +156,8 @@ class DataLoader:
 
     def check_filelist_against_sqlite(self):
         """Compares file list to sqlite database. Insert files if they aren't
-        present. Updates paths if files found have moved since last seen.
+        present. Updates paths if files found have moved since they were last
+        seen.
 
         """
         c = self.sqliteconn.cursor()
@@ -173,15 +178,27 @@ class DataLoader:
         c.close()
 
     def _publish_file(self, filename):
-        """Publish the contents of a .g3 file to InfluxDB."""
+        """Publish the contents of a .g3 file to InfluxDB.
+
+        Parameters
+        ----------
+        filename : str
+            Full path to file to publish.
+
+        """
         scanner = SingleFileScanner(filename, self.influxclient)
         scanner.run()
 
     def publish_all_files_to_influxdb(self):
         """Publish all files found in target to InfluxDB.
 
-        Will check if file has been published already, if not, will scan and
-        publish contents, then mark as published in sqliteDB.
+        Will build list of files not already published from sqlite database,
+        scan and publish contents, then mark as published in sqliteDB.
+
+        This has the side-effect that it will publish files previously entered
+        into the database, even if not in the target list for this particular call, say
+        if a previous upload was cancelled. This should probably be addressed in
+        future versions.
 
         """
         c = self.sqliteconn.cursor()
@@ -189,13 +206,10 @@ class DataLoader:
         c.execute("SELECT path, md5sum from g3files WHERE published=0")
         to_publish = c.fetchall()
 
-        _bar = Bar('Publishing', max=len(to_publish))
-        for path, chksum in to_publish:
+        for path, chksum in tqdm(to_publish, desc="All Files"):
             self._publish_file(path)
             c.execute("UPDATE g3files SET published=1 WHERE md5sum=?", (chksum, ))
             self.sqliteconn.commit()
-            _bar.next()
-        _bar.finish()
 
     def run(self):
         self.check_filelist_against_sqlite()
@@ -203,6 +217,37 @@ class DataLoader:
 
 
 class SingleFileScanner:
+    """Object for scanning and publishing a single .g3 file.
+
+    Since we want to track which files are being uploaded so that an upload can
+    be resumed if interrupted it's perhaps the simplest to upload them
+    individually. While this doesn't take advantage of the nice
+    so3g.hk.HKArchiveScanner functionality of reading multiple files, or time
+    limiting step is actually pushing data into the InfluxDB.
+
+    Parameters
+    ----------
+    filename : str
+        Full path to file for scanning
+    influxdb : influxdb.InfluxDBClient
+        Connection to the InfluxDB, used to publish data to the database.
+
+    Attributes
+    ----------
+    file : str
+        Full path to file for scanning
+    client : influxdb.InfluxDBClient
+        Connection to the InfluxDB, used to publish data to the database.
+    hkas : so3g.hk.HKArchiveScanner
+        HKArchiveScanner for reading in the data
+    cat :
+        Finalized HKArchiveScanner
+    fields
+        Fields within the file as returned by cat.get_fields()
+    timelines
+        Timelines within the file as returned by cat.get_fields()
+
+    """
     def __init__(self, filename, influxdb):
         self.file = filename
         self.client = influxdb
@@ -220,9 +265,9 @@ class SingleFileScanner:
         """
         self.hkas.process_file(self.file)
         self.cat = self.hkas.finalize()
-        print("Getting fields")
+        # print("Getting fields")
         self.fields, self.timelines = self.cat.get_fields()
-        print("fields acquired")
+        # print("fields acquired")
 
     def format_field(self, field):
         """Format a given field for publishing to the database.
@@ -231,8 +276,11 @@ class SingleFileScanner:
         ----------
         field : str
             Field to publish data from, will query the finalized HKArchive
-        batch_size : int
-            Number of points to publish per write, passed to influxdb.write_points()
+
+        Returns
+        -------
+        list
+            List of values formatted for writing to InfluxDB
 
         """
         t, x = self.cat.simple(field)
@@ -248,28 +296,49 @@ class SingleFileScanner:
                     "measurement": agent_address,
                     "time": timestamp2influxtime(_t),
                     "fields": fields,
-                    "tags" : {
+                    "tags": {
                         "feed": feed_tag
                     }
 
                 }
             )
 
-        #print("payload: {}".format(json_body))
+        # print("payload: {}".format(json_body))
 
         return json_body
 
     def publish_file(self, batch_size=10000):
-        for field in self.fields:
+        """Publish a files contents to InfluxDB.
+
+        Parameters
+        ----------
+        batch_size : int
+            Number of points to publish per write, passed to
+            influxdb.write_points(). Defaults to 10,000, which seems
+            reasonable.
+
+        """
+        basename = os.path.basename(self.file)
+        for field in tqdm(self.fields, desc=f"{basename} Fields"):
             payload = self.format_field(field)
-            print(f"publishing {field}...")
+            # print(f"publishing {field}...")
             self.client.write_points(payload, batch_size=batch_size)
 
     def run(self):
         self.scan_file()
         self.publish_file()
 
-dl = DataLoader('/home/koopman/data/15760/')
-dl.run()
 
-#payload = dl.publish_field(list(dl.fields)[0])
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('target', help='File or directory to scan.')
+    # parser.add_argument('--docker', '-d', action='store_true',
+    #                     help='Force use of docker, even if so3g is installed.')
+    args = parser.parse_args()
+
+    dl = DataLoader(args.target)
+    dl.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -372,7 +372,7 @@ def main():
     numeric_level = getattr(logging, args.log.upper(), None)
     if not isinstance(numeric_level, int):
         raise ValueError('Invalid log level: %s' % loglevel)
-    logging.basicConfig(level=numeric_level)
+    logging.basicConfig(filename='g32influx.log', level=numeric_level)
 
     dl = DataLoader(args.target, host=args.host, port=args.port)
     dl.run()

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -144,7 +144,7 @@ class DataLoader:
         db_names = [x['name'] for x in db_list]
 
         if 'ocs_feeds' not in db_names:
-            print("ocs_feeds DB doesn't exist, creating DB")
+            logging.info("ocs_feeds DB doesn't exist, creating DB")
             self.influxclient.create_database(db)
 
         self.influxclient.switch_database(db)
@@ -190,11 +190,11 @@ class DataLoader:
             c.execute("SELECT * from g3files WHERE md5sum=?", (md5, ))
             result = c.fetchone()
             if result is None:
-                print(f"No match for {md5}, inserting into SQLiteDB")
+                logging.info(f"No match for {md5}, inserting into SQLiteDB")
                 c.execute("INSERT INTO g3files VALUES (?, ?, 0)", (f, md5))
                 self.sqliteconn.commit()
             elif result[0] != f:
-                print(f"Path changed for hash {md5}, updating path to {f}")
+                logging.info(f"Path changed for hash {md5}, updating path to {f}")
                 c.execute("UPDATE g3files SET path=? WHERE md5sum=?", (f, md5))
                 self.sqliteconn.commit()
 

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -296,11 +296,18 @@ class SingleFileScanner:
         for later processing.
 
         """
-        self.hkas.process_file(self.file)
+        try:
+            self.hkas.process_file(self.file)
+        except RuntimeError:
+            logging.error("Unable to process file, skipping.")
+
+            return 2
         self.cat = self.hkas.finalize()
         # print("Getting fields")
         self.fields, self.timelines = self.cat.get_fields()
         # print("fields acquired")
+
+        return 0
 
     def format_field(self, field):
         """Format a given field for publishing to the database.
@@ -379,10 +386,10 @@ class SingleFileScanner:
         return return_value
 
     def run(self):
-        self.scan_file()
+        scan_ret = self.scan_file()
         pub_ret = self.publish_file()
 
-        return pub_ret
+        return pub_ret + scan_ret
 
 
 def main():

--- a/ocs/checkdata.py
+++ b/ocs/checkdata.py
@@ -57,6 +57,13 @@ class DataChecker:
         File or directory to scan.
     verbose : bool
         Verbose output flag
+    fields : dict
+        fields returned from a cat.get_fields call
+    timelines : dict
+        timelines returned from a cat.get_fields call
+    instances : dict
+        Agent/feed/field information for each instance-id, format described in
+        _populate_instances docstring
 
     """
     def __init__(self, target, verbose=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,9 @@ sphinx-argparse
 progress
 colorama
 
+# g32influx
+tqdm
+
 # testing
 pytest
 pytest-cov


### PR DESCRIPTION
As I work on assessing the scalability of `influxdb` as an "official" storage format, I've made some modifications to this script.

Speed is greatly improved (on my laptop, ~5 seconds per file instead of ~1 minute):
- By using line format rather than JSON for writing to `influxdb` DB.
- By writing whole timelines at once time rather than field-by-field.

Rather than using a standalone `sqlite` DB to record which files have been written, there is now a measurement in the `influxdb` DB, `.g32influx.log`, that records when files have been completed (and also records if they have been started, as well as if an error has occurred. This can be queried to determine whether a file needs to be written or not (which can be overridden with `-f`).

In addition to the `feed` tag, an `md5sum` tag is added to each HK point so that the provenance of data can be traced.
 - One thing to test for is whether this increases the series cardinality too much. Based on [this guideline](https://docs.influxdata.com/influxdb/v1.7/guides/hardware_sizing/#general-hardware-guidelines-for-a-single-node) I think it's going to be OK, but will want to assess this.

Although I'm creating this pull request here so that you can see the changes, it could reflect a simple branch of this code away from `ocs` as I continue my own investigation. So, if you have concerns about anything I've done here and don't think this belongs in `ocs`, no problem.