### PR TITLE
Updated registry agent

### DIFF
--- a/agents/registry/registry.py
+++ b/agents/registry/registry.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 class RegisteredAgent:
     """
-        Contain data about registered agents.
+        Contains data about registered agents.
 
         Attributes:
             exipred (bool):
@@ -77,7 +77,7 @@ class Registry:
 
     def _register_heartbeat(self, _data):
         """ 
-            Function that is called whenever a heartbeat is received by an agent.
+            Function that is called whenever a heartbeat is received from an agent.
             It will update that agent in the Registry's registered_agent dict.
         """
         data, feed = _data
@@ -86,7 +86,7 @@ class Registry:
     @inlineCallbacks
     def run(self, session: ocs_agent.OpSession, params=None):
         """
-            Main run process for Registry agent. This will loop and keep track of
+            Main run process for the Registry agent. This will loop and keep track of
             which agents have expired. It will keep track of current active agents
             in the session.data variable so it can be seen by clients.
         """

--- a/agents/registry/registry.py
+++ b/agents/registry/registry.py
@@ -105,11 +105,21 @@ class Registry:
             session.data = {
                 k: agent.encoded() for k, agent in self.registered_agents.items()
             }
+        return True, "Stopped registry main process"
 
     def stop(self, session, params=None):
         """Stop function for the 'run' process."""
         session.set_status('stopping')
         self._run = False
+
+    def _register_agent(self, session, agent_data):
+        self.log.warn(
+            "Warning!!! The register_agent task has been depricated. Agent '{}' "
+            "is using an out of date version of ocs or socs!!"
+            .format(agent_data['agent_address'])
+        )
+
+        return True, "'register_agent' is depricated"
 
 
 if __name__ == '__main__':
@@ -120,6 +130,7 @@ if __name__ == '__main__':
     registry = Registry(agent)
 
     agent.register_process('run', registry.run, registry.stop, blocking=False, startup=True)
+    agent.register_task('register_agent', registry._register_agent, blocking=False)
     
     runner.run(agent, auto_reconnect=True)
 

--- a/docs/agents/registry.rst
+++ b/docs/agents/registry.rst
@@ -10,10 +10,10 @@ It listens to the heartbeat feeds of all agents on the crossbar server,
 and keeps track of the last heartbeat time of each agent and whether 
 or not each agent has agent has "expired" (gone 5 seconds without a heartbeat).
 
-This check happens in the registry's single "run" process. The session.data object
+This check happens in the registry's single "main" process. The session.data object
 of this process is set to a dict of agents on the system, including their last 
 heartbeat time, whether they have expired, and the time at which they expired.
-This data can the be viewed by checking the session variable of the run process.
+This data can the be viewed by checking the session variable of the main process.
 
 For instance, the following code will print agent's that have been on the system
 since the registry started running::
@@ -21,9 +21,25 @@ since the registry started running::
     from ocs.matched_client import MatchedClient
 
     registry_client = MatchedClient('registry')
-    status, msg, session = registry_client.run.status()
+    status, msg, session = registry_client.main.status()
 
     print(session['data'])
+
+which will print a dictionary that might look like::
+
+    {'observatory.aggregator':
+        {'expired': False,
+         'last_updated': 1583179794.5175,
+         'time_expired': None},
+     'observatory.faker1':
+        {'expired': False,
+         'last_updated': 1583179795.072248,
+         'time_expired': None},
+     'observatory.faker2':
+        {'expired': True,
+         'last_updated': 1583179777.0211036,
+         'time_expired': 1583179795.3862052}}
+
 
 
 Configuration


### PR DESCRIPTION
I've been meaning to update the registry for a while to make it more stable and usable, in the same vein as the aggregator update. I thought now would be a good time since Yuhan is assigned to create an "ocs health" script for the smurf-server and needs an easy way to get registered agents.

This update removes the need for agents to call a 'register_agent' task. Instead, it monitors all heartbeat feeds, and keeps a collection of what agents it hears. For each of these agents it keeps track of the last updated time, whether that agent has expired, and the time at which it expires. There is a single non-blocking "run" process that loops and checks if any agents have expires, and maintains this info in the session.data object.

To get a list of agent status, all you then need to do is create a client for the registry and run `registry.run.status()` to get the session info.

Working on docs now but thought I'd submit this for review