### PR TITLE
Create script to convert .g3 filenames to new ctime format

### DIFF
--- a/bin/datestring2ctime
+++ b/bin/datestring2ctime
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Brian Koopman
+
+# Scan a directory for all .g3 files matching the old naming convension of
+# "%Y-%m-%d-%H-%M-%S.g3" and convert them to "ctime.g3".
+
+# Usage: ./datestring2ctime /data/ -v
+
+import argparse
+from ocs import rename
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('target', help='File or directory to process.')
+    parser.add_argument('--verbose', '-v', action='count')
+    args = parser.parse_args()
+
+    rename.main(args.target, args.verbose)
+
+if __name__ == "__main__":
+    main()

--- a/docs/user/cli_tools.rst
+++ b/docs/user/cli_tools.rst
@@ -97,3 +97,23 @@ field within that feed. For more verbose output, throw the ``-v`` flag::
               Channel 01 R |                320.4 |   1573212564.6585813 |              29255.1
               Channel 01 T |                320.4 |   1573212564.6585813 |            0.0656435
 
+datestring2ctime
+================
+The HK Aggregator originally output .g3 files with the naming convention
+``%Y-%m-%d-%H-%M-%S.g3``. After some time we decided to move to a ctime based
+filename, i.e. ``1582661596.g3``. To facilitate the move the `datestring2ctime`
+script was created. It will rename all datestring based .g3 files in a given
+directory to the ctime convention.
+
+.. warning:: The script is safe to run, but be aware of what you are doing, and that is
+             renaming every .g3 file matching the old convention. This has the potential to
+             break scripts you have written that read in files, especially if that do any
+             parsing of the names.
+
+To use the script run::
+
+    ./datestring2ctime target -v
+
+The passed target can be a single file or directory. The ``-v`` flag indicates
+you'd like verbose output, however this is not required. Without it there will
+be no output.

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -51,9 +51,6 @@ def make_filename(base_dir, make_subdirs=True):
             True if func should automatically create non-existing subdirs.
     """
     start_time = time.time()
-    start_datetime = datetime.datetime.fromtimestamp(
-        start_time, tz=datetime.timezone.utc
-    )
 
     subdir = os.path.join(base_dir, "{:.5}".format(str(start_time)))
 
@@ -64,7 +61,7 @@ def make_filename(base_dir, make_subdirs=True):
             raise FileNotFoundError("Subdir {} does not exist"
                                     .format(subdir))
 
-    time_string = int(start_datetime.timestamp())
+    time_string = int(start_time)
     filename = os.path.join(subdir, "{}.g3".format(time_string))
     return filename
 

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -64,7 +64,7 @@ def make_filename(base_dir, make_subdirs=True):
             raise FileNotFoundError("Subdir {} does not exist"
                                     .format(subdir))
 
-    time_string = start_datetime.strftime("%Y-%m-%d-%H-%M-%S")
+    time_string = int(start_datetime.timestamp())
     filename = os.path.join(subdir, "{}.g3".format(time_string))
     return filename
 

--- a/ocs/rename.py
+++ b/ocs/rename.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# Brian Koopman
-
 import os
 import datetime
 

--- a/ocs/rename.py
+++ b/ocs/rename.py
@@ -55,8 +55,6 @@ def _remove_non_matching_files(filelist, verbose=None):
         except ValueError:
             if verbose is not None:
                 print(f"{f} does not match datestring format, removing from list.")
-            else:
-                pass
 
     return new_list
 

--- a/ocs/rename.py
+++ b/ocs/rename.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# Brian Koopman
+
+import os
+import datetime
+
+def _find_all_g3_files(target):
+    """Build list of .g3 files.
+
+    Parameters
+    ----------
+    target : str
+        File or directory to scan.
+
+    Returns
+    -------
+    list
+        List of full paths to .g3 files.
+
+    """
+    _file_list = []
+    if os.path.isfile(target):
+        _file_list.append(target)
+    elif os.path.isdir(target):
+        a = os.walk(target)
+        for root, _, _file in a:
+            for g3 in _file:
+                if g3[-2:] == "g3":
+                    _file_list.append(os.path.join(root, g3))
+
+    return _file_list
+
+def _remove_non_matching_files(filelist, verbose=None):
+    """Make new list, removing files that don't match the known stringtime format.
+
+    If the script was partially run on a directory, newly renamed files will
+    cause errors at the strptime step, so remove them.
+
+    Parameters
+    ----------
+    filelist : list
+        List of files, probably made by _find_all_g3_files()
+    verbose : int
+        Verbosity level.
+
+    Returns
+    -------
+    list
+        List of full paths to .g3 files.
+
+    """
+    new_list = []
+    for f in filelist:
+        try:
+            basename = os.path.basename(f)
+            datetime.datetime.strptime(basename, "%Y-%m-%d-%H-%M-%S.g3")
+            new_list.append(f)
+        except ValueError:
+            if verbose is not None:
+                print(f"{f} does not match datestring format, removing from list.")
+            else:
+                pass
+
+    return new_list
+
+def build_filelist(target, verbose=None):
+    """Build .g3 filelist to process.
+
+    This is done in two steps, finding all *.g3 files, then making sure they
+    match the old naming convention.
+
+    Parameters
+    ----------
+    target : str
+        File or directory to scan.
+    verbose : int
+        Verbosity level.
+
+    Returns
+    -------
+    list
+        List of full paths to .g3 files.
+
+    """
+
+    _filelist = _find_all_g3_files(target)
+    filelist = _remove_non_matching_files(_filelist, verbose)
+
+    return filelist
+
+def _generate_ctime_filename(path):
+    """Determine the ctime corresponding to a datestring formatted filename.
+
+    Note: Files must be named with a UTC timestamp for this to work properly.
+    However, the code works on any timezone machine. If files are not named based
+    on UTC timestamps, then this will result in a shifted timestamp after
+    conversion.
+
+    Paramters
+    ---------
+    path : str
+        Full path to old datestring style .g3 file.
+
+    Returns
+    -------
+    str
+        File basename in new ctime based format.
+
+    """
+    basename = os.path.basename(path)
+    dt = datetime.datetime.strptime(basename, "%Y-%m-%d-%H-%M-%S.g3")
+    ctime = int(dt.replace(tzinfo=datetime.timezone.utc).timestamp())
+    new_filename = f"{ctime}.g3"
+
+    return new_filename
+
+def _rename_file(path, verbose=None):
+    """Rename a single file from "%Y-%m-%d-%H-%M-%S.g3" to "ctime.g3".
+
+    Paramters
+    ---------
+    path : str
+        Filename for .g3 file.
+    verbose : int
+        Verbosity level.
+
+    """
+    dirname = os.path.dirname(path)
+    new_filename = _generate_ctime_filename(path)
+    new_path = os.path.join(dirname, new_filename)
+    if verbose is not None:
+        print(f"Renaming {path} to {new_path}")
+
+    # Don't overwrite any existing file.
+    if os.path.isfile(new_path):
+        raise OSError("File at dst, {new_path}, already exists!")
+
+    os.rename(path, new_path)
+
+def rename_files(path, verbose=None):
+    """Rename all .g3 file in path to new ctime based format.
+
+    Paramters
+    ---------
+    path : str
+        Filename for .g3 file.
+    verbose : int
+        Verbosity level.
+
+    """
+    filelist = build_filelist(path, verbose)
+
+    for f in filelist:
+        _rename_file(f, verbose)
+
+def main(target, verbose=None):
+    rename_files(target, verbose)

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,0 +1,13 @@
+import pytest
+import os
+from pathlib import Path
+
+from ocs import rename
+
+def test_rename_files(tmpdir):
+    p = tmpdir.mkdir("data")
+    Path(os.path.join(p, "2020-01-01-12-00-00.g3")).touch()
+
+    rename.rename_files(p)
+
+    assert os.path.isfile(os.path.join(p, "1577880000.g3"))

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -4,10 +4,56 @@ from pathlib import Path
 
 from ocs import rename
 
-def test_rename_files(tmpdir):
+def test_rename_main(tmpdir):
+    """Test rename.main(), should hit most of the rename module. Tests renaming
+    a directory with a single file in it.
+
+    """
     p = tmpdir.mkdir("data")
     Path(os.path.join(p, "2020-01-01-12-00-00.g3")).touch()
 
-    rename.rename_files(p)
+    rename.main(p, verbose=1)
 
     assert os.path.isfile(os.path.join(p, "1577880000.g3"))
+
+def test_rename_single_file(tmpdir):
+    """target can be a single file, so we test tarting a file instead of a
+    directory.
+
+    """
+    p = tmpdir.mkdir("data")
+    filename = "2020-01-01-12-00-00.g3"
+    Path(os.path.join(p, filename)).touch()
+
+    rename.main(os.path.join(p, filename))
+
+    assert os.path.isfile(os.path.join(p, "1577880000.g3"))
+
+def test_nonmatching_filename(tmpdir):
+    """Files must match the datestring time format, else we won't run them.
+    Test that we skip these files.
+
+    """
+    p = tmpdir.mkdir("data")
+    filename = "2020-01-01-12-00-00_non_match.g3"
+    Path(os.path.join(p, filename)).touch()
+
+    rename.main(os.path.join(p, filename))
+    rename.main(os.path.join(p, filename), verbose=1)
+
+    # file should remain unaffected
+    assert os.path.isfile(os.path.join(p, filename))
+
+def test_file_collision(tmpdir):
+    """If we somehow end up with a matching timestring we shouldn't overwrite
+    the existing file. This checks an error is raised in this case.
+
+    """
+    p = tmpdir.mkdir("data")
+    filename = "2020-01-01-12-00-00.g3"
+    Path(os.path.join(p, filename)).touch()
+    # Make our own renamed file to collide
+    Path(os.path.join(p, "1577880000.g3")).touch()
+
+    with pytest.raises(OSError):
+        rename.main(os.path.join(p, filename))


### PR DESCRIPTION
At the SMuRF/DAQ Workshop we talked about renaming old .g3 files from the `"%Y-%m-%d-%H-%M-%S"` format to one based on ctime `ctime.g3`.

This PR introduces `datestring2ctime`, a script in `ocs/bin/` that converts all .g3 files in a given directory (also works on single files if you want to do that for some reason).

We also change the naming format in the Aggregator itself. Note, a similar change needs to happen on the socs timestream-aggregator.