### PR TITLE
MatchedClient: wrap replies with a nice __repr__ for interactive use

### DIFF
--- a/docs/developer/clients.rst
+++ b/docs/developer/clients.rst
@@ -174,7 +174,7 @@ parameter expansion syntax::
 Replies from Operation methods
 ==============================
 
-The responses from Operation methods is a tuple, (success, message,
+The responses from Operation methods is a tuple, (status, message,
 session).  The elements of the tuple are:
 
   ``status``

--- a/docs/developer/clients.rst
+++ b/docs/developer/clients.rst
@@ -168,3 +168,79 @@ parameter expansion syntax::
     therm_client.init.start(**params)
     therm_client.init.wait()
     time.sleep(.05)
+
+
+
+Replies from Operation methods
+==============================
+
+The responses from Operation methods is a tuple, (success, message,
+session).  The elements of the tuple are:
+
+  ``status``
+    An integer value equal to ocs.OK, ocs.ERROR, or ocs.TIMEOUT.
+    
+  ``message``
+    A string providing a brief description of the result (this is
+    normally pretty boring for successful calls, but might contain a
+    helpful tip in the case of errors).
+
+  ``session``
+    The session information... see below.
+
+Responses obtained from MatchedClient calls are lightly wrapped by
+class ``OCSReply`` so that ``__repr__`` produces a nicely formatted
+description of the result.  For example::
+
+  >>> c.set_autoscan.wait()
+  OCSReply: OK : Operation "set_autoscan" just exited.
+    set_autoscan[session=7]; status=done without error 30.6 s ago, took 0.113400 s
+    messages (4 of 4):
+      1585667844.423 Status is now "starting".
+      1585667844.424 Status is now "running".
+      1585667844.535 Set autoscan to True
+      1585667844.536 Status is now "done".
+    other keys in .status: data
+
+
+The ``session`` portion of the reply is dictionary containing a bunch
+of potentially useful information.  This information corresponds to
+the OpSession maintained by the OCSAgent class for each run of an
+Agent's Operation (see OpSession in ocs/ocs_agent.py):
+
+  ``'session_id'``
+    An integer identifying this run of the Operation.  If an Op ends
+    and is started again, ``session_id`` will be different.
+
+  ``'op_name'``
+    The operation name.  You probably already know this.
+  
+  ``'status'``
+    A string representing the state of the operation.  The possible
+    values are 'starting', 'running', 'done'.
+  
+  ``'start_time'``
+    The timestamp corresponding to when this run was started.
+
+  ``'end_time'``
+    If ``status`` == ``'done'``, then this is the timestamp at which
+    the run completed.  Otherwise it will be None.
+  
+  ``'success'``
+    If ``status`` == ``'done'``, then this is a boolean indicating
+    whether the operation reported that it completed successfully
+    (rather than with an error).
+  
+  ``'data'``
+    Agent-specific data that might of interest to a user.  This may be
+    updated while an Operation is running, but once ``status`` becomes
+    ``'done'`` then ``data`` should not change any more.  A typical
+    use case here would be for a Process that is monitoring some
+    system to report the current values of key parametrs.  This should
+    not be used as an alternative to providing a data feed... rather
+    it should provide current values to answer immediate questions.
+  
+  ``'messages'``
+    A list of Operation log messages.  Each entry in the list is a
+    tuple, (timestamp, text).
+

--- a/ocs/matched_client.py
+++ b/ocs/matched_client.py
@@ -105,13 +105,13 @@ def humanized_time(t):
 
 
 class OCSReply(collections.namedtuple('_OCSReply',
-                                      ['ok', 'msg', 'status'])):
+                                      ['status', 'msg', 'session'])):
     def __repr__(self):
         ok_str = {ocs.OK: 'OK', ocs.ERROR: 'ERROR',
                   ocs.TIMEOUT: 'TIMEOUT'}.get(self.ok, '???')
         text = 'OCSReply: %s : %s\n' % (ok_str, self.msg)
-        if self.status is None or len(self.status.keys()) == 0:
-            return text + '  (no status -- op has never run)'
+        if self.session is None or len(self.session.keys()) == 0:
+            return text + '  (no session -- op has never run)'
 
         # try/fail in here so we can make assumptions about key
         # presence and bail out to a full dump if anything is weird.
@@ -119,7 +119,7 @@ class OCSReply(collections.namedtuple('_OCSReply',
             handled = ['op_name', 'session_id', 'status', 'start_time',
                        'end_time', 'messages', 'success']
 
-            s = self.status
+            s = self.session
             run_str = 'status={status}'.format(**s)
             if s['status'] in ['starting', 'running']:
                 run_str += ' for %s' % humanized_time(
@@ -143,10 +143,10 @@ class OCSReply(collections.namedtuple('_OCSReply',
 
             also = [k for k in s.keys() if k not in handled]
             if len(also):
-                text += ('  other keys in .status: ' + ', '.join(also))
+                text += ('  other keys in .session: ' + ', '.join(also))
 
         except Exception as e:
-            text += ('\n  [status decode failed with exception: %s\n'
-                     '  Here is everything in .status:\n %s\n]') \
-                     % (e.args, self.status)
+            text += ('\n  [session decode failed with exception: %s\n'
+                     '  Here is everything in .session:\n %s\n]') \
+                     % (e.args, self.session)
         return text


### PR DESCRIPTION
MatchedClient operation calls return an object with a nice ```__repr__``` string, e.g.:

```
  >>> c.set_autoscan.wait()
  OCSReply: OK : Operation "set_autoscan" just exited.
    set_autoscan[session=7]; status=done without error 30.6 s ago, took 0.113400 s
    messages (4 of 4):
      1585667844.423 Status is now "starting".
      1585667844.424 Status is now "running".
      1585667844.535 Set autoscan to True
      1585667844.536 Status is now "done".
    other keys in .status: data
```

This still works with the form "ok, msg, status = op.status()", for
example, because the OCSReply object is still a tuple, deep down...