### PR TITLE
MatchedClient: make MatchedTask and MatchedProcess callable

### DIFF
--- a/ocs/matched_client.py
+++ b/ocs/matched_client.py
@@ -1,3 +1,4 @@
+import ocs
 from ocs import site_config
 
 
@@ -20,10 +21,19 @@ def get_op(op_type, name, session, encoded, client):
     class MatchedTask(MatchedOp):
         def abort(self):
             return client.request('abort', name)
+        def __call__(self, **kw):
+            """Runs self.start(**kw) and, if that succeeds, self.wait()."""
+            result = self.start(**kw)
+            if result[0] != ocs.OK:
+                return result
+            return self.wait()
 
     class MatchedProcess(MatchedOp):
         def stop(self):
             return client.request('stop', name)
+        def __call__(self):
+            """Equivalent to self.status()."""
+            return self.status()
 
     MatchedOp.start.__doc__ = encoded['docstring']
 
@@ -87,3 +97,4 @@ class MatchedClient:
         for name, session, encoded in self._client.get_processes():
             setattr(self, opname_to_attr(name),
                     get_op('process', name, session, encoded, self._client))
+


### PR DESCRIPTION
This is another suggestion for improving interactive use / scripting.  Calling start() and wait() separately when you want to run a Task is an important option to have, in our asynchronous architecture.  But in practice it is often just annoying.

For a Process, start() and wait() is not as useful a shortcut.  So instead we just have ```__call__`` map to status().

I acknowledge that having ```__call__``` do different things for Tasks and Processes is slightly weird.  But Tasks and Processes are different!

