### PR TITLE
Switched from IrregBlockDouble to G3Timesample

### DIFF
--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -1,11 +1,8 @@
 import os
-import datetime
 import binascii
 import time
-
-from typing import Dict
-
 import txaio
+from typing import Dict
 
 from ocs import ocs_feed
 
@@ -18,6 +15,7 @@ else:
     G3Module = object
 
 
+HKAGG_VERSION = 1
 _g3_casts = {
     str: core.G3String, int: core.G3Int, float: core.G3Double,
 }
@@ -305,7 +303,7 @@ class G3FileRotator(G3Module):
         by `filename` function passed to constructor
         """
         for frame in frames:
-
+            frame['hkagg_version'] = HKAGG_VERSION
             ftype = frame['hkagg_type']
 
             if ftype == so3g.HKFrameType.session:

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -303,7 +303,6 @@ class G3FileRotator(G3Module):
         by `filename` function passed to constructor
         """
         for frame in frames:
-            frame['hkagg_version'] = HKAGG_VERSION
             ftype = frame['hkagg_type']
 
             if ftype == so3g.HKFrameType.session:
@@ -371,7 +370,8 @@ class Aggregator:
     def __init__(self, incoming_data, time_per_file, data_dir):
         self.log = txaio.make_logger()
 
-        self.hksess = so3g.hk.HKSessionHelper(description="HK data")
+        self.hksess = so3g.hk.HKSessionHelper(description="HK data",
+                                              hkagg_version=HKAGG_VERSION)
         self.hksess.start_time = time.time()
         self.hksess.session_id = generate_id(self.hksess)
 

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -33,13 +33,15 @@ def g3_cast(data, time=False):
         str   -> G3String
         float -> G3Double
     and lists of type X will go to G3VectorX. If ``time`` is set to True, will
-    convert to G3Time or G3VectorTime.
+    convert to G3Time or G3VectorTime with the assumption that ``data`` consists
+    of unix timestamps.
 
     Args:
         data (int, str, float, or list):
             Generic data to be converted to a corresponding G3Type.
         time (bool, optional):
-            If True, will try to cast to G3Time or G3VectorTime.
+            If True, will assume data contains unix timestamps and try to cast
+            to G3Time or G3VectorTime.
 
     Returns:
         g3_data:
@@ -57,13 +59,14 @@ def g3_cast(data, time=False):
                         "be one of {}".format(dtype, _g3_casts.keys()))
     if is_list:
         if time:
-            return core.G3VectorTime(list(map(core.G3Time, data)))
+            return core.G3VectorTime(list(map(
+                lambda t: core.G3Time(t * core.G3Units.s), data)))
         else:
             cast = _g3_list_casts[type(data[0])]
             return cast(data)
     else:
         if time:
-            return core.G3Time(data)
+            return core.G3Time(data * core.G3Units.s)
         else:
             cast = _g3_casts[type(data)]
             return cast(data)

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -2,8 +2,9 @@ import time
 import pytest
 
 import so3g
+from spt3g import core
 
-from ocs.agent.aggregator import Provider
+from ocs.agent.aggregator import Provider, g3_cast
 
 def test_passing_float_in_provider_to_frame():
     """Float is the expected type we should be passing.
@@ -88,3 +89,25 @@ def test_data_type_in_provider_write():
                      'prefix': ''}
            }
     provider.write(data)
+
+
+def test_g3_cast():
+    correct_tests = [
+        ([1, 2, 3, 4], core.G3VectorInt),
+        ([1., 2., 3.], core.G3VectorDouble),
+        (["a", "b", "c"], core.G3VectorString),
+        (3, core.G3Int),
+        ("test", core.G3String)
+    ]
+    for x, t in correct_tests:
+        assert isinstance(g3_cast(x), t)
+
+    assert isinstance(g3_cast(3, time=True), core.G3Time)
+    assert isinstance(g3_cast([1, 2, 3], time=True), core.G3VectorTime)
+
+    incorrect_tests = [
+        ['a', 'b', 1, 2], True, [1, 1.0, 2]
+    ]
+    with pytest.raises(TypeError) as e_info:
+        for x in incorrect_tests:
+            g3_cast(x)

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -108,6 +108,6 @@ def test_g3_cast():
     incorrect_tests = [
         ['a', 'b', 1, 2], True, [1, 1.0, 2]
     ]
-    with pytest.raises(TypeError) as e_info:
-        for x in incorrect_tests:
+    for x in incorrect_tests:
+        with pytest.raises(TypeError) as e_info:
             g3_cast(x)


### PR DESCRIPTION
This PR switches the aggregator to using the G3Timesample object to store data instead of IrregBlockDouble. It uses a helper function `g3_cast` to attempt to cast a python object into the corresponding G3 datatype, with int, str, float --> G3Int, G3String, and G3Double, and lists of a single data type X being casted to G3VectorX. I also add some tests for the `g3_cast` function so you can see cases in which it will/won't work. The type checking also now occurs in this `g3_cast` function, since if the data is of an unsupported type, or is a list of inconsistent types, a TypeError will be raised and handled by the aggregator.