### PR TITLE
Field name validation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,6 +3,20 @@ API
 
 This page contains the auto-generated documentation for the ocs package.
 
+agent
+-----
+
+The ``agent/`` directory contains code that supports particular OCS Agents.
+Having this code in the ocs library facilitates testing.
+
+agent.aggregator
+````````````````
+
+.. automodule:: ocs.agent.aggregator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 ocs.base
 --------
 

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -167,7 +167,7 @@ class Provider:
                 try:
                     ocs_feed.Feed.verify_data_field_string(field_name)
                 except ValueError:
-                    self.log.error("data field name {field} is " +
+                    self.log.error("data field name '{field}' is " +
                                    "invalid, removing invalid characters.",
                                    field=field_name)
                     verified = False
@@ -195,8 +195,11 @@ class Provider:
                  through this method, and that should be checked.
 
         """
+        # replace spaces with underscores
+        new_field_name = field_name.replace(' ', '_')
+
         # replace invalid characters
-        new_field_name = re.sub('[^a-zA-Z0-9_]', '', field_name)
+        new_field_name = re.sub('[^a-zA-Z0-9_]', '', new_field_name)
 
         # grab leading underscores
         underscore_search = re.compile('^_*')

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -458,7 +458,7 @@ class Aggregator:
     def remove_stale_providers(self):
         """
         Loops through all providers and check if they've gone stale. If they
-         have, write their remaining data to disk (they shouldn't have any)
+        have, write their remaining data to disk (they shouldn't have any)
         and delete them.
         """
         stale_provs = []

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -150,7 +150,7 @@ class Provider:
 
         return True
 
-    def write(self, data):
+    def save_to_block(self, data):
         """
         Saves a list of data points into blocks.
         A block will be created for any new block_name.
@@ -331,9 +331,8 @@ class G3FileRotator(G3Module):
 
 
 class Aggregator:
-    """
-    Data aggregator. This manages a collection or providers, and contains
-    methods to write to them and write them to disk.
+    """Data aggregator. This manages a collection of providers, and contains
+    methods to write them to disk.
 
     This class should only be accessed by a single thread. Data can be passed
     to it by appending it to the referenced `incoming_data` queue.
@@ -407,7 +406,7 @@ class Aggregator:
                 pid = self.add_provider(address, sessid, **feed['agg_params'])
 
             prov = self.providers[pid]
-            prov.write(data)
+            prov.save_to_block(data)
 
     def add_provider(self, prov_address, prov_sessid, **prov_kwargs):
         """

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -193,8 +193,25 @@ class Provider:
                 if k == 'data':
                     new_data[block_name]['data'] = {}
                     for field_name, field_values in block_dict['data'].items():
-                        # replace invalid characters, and limit to 255 characters
-                        new_field_name = re.sub('[^a-zA-Z0-9_]', '', field_name)[:255]
+                        # replace invalid characters
+                        new_field_name = re.sub('[^a-zA-Z0-9_]', '', field_name)
+                        
+                        # grab leading underscores
+                        underscore_search = re.compile('^_*')
+                        underscores = underscore_search.search(new_field_name).group()
+
+                        # remove leading underscores
+                        new_field_name = re.sub('^_*', '', new_field_name)
+
+                        # remove leading non-letters
+                        new_field_name = re.sub('^[^a-zA-Z]*', '', new_field_name)
+
+                        # add underscores back 
+                        new_field_name = underscores + new_field_name
+
+                        # limit to 255 characters
+                        new_field_name = new_field_name[:255]
+
                         new_data[block_name]['data'][new_field_name] = field_values
                 else:
                     new_data[block_name][k] = v

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -290,14 +290,6 @@ class Provider:
             hk.t = block.timestamps
             for key, ts in block.data.items():
                 try:
-                    ocs_feed.Feed.verify_data_field_string(key)
-                except ValueError:
-                    self.log.error("data field name {field} is " +
-                                   "invalid, removing invalid characters.",
-                                   field=key)
-                    key = re.sub('[^a-zA-Z0-9_]', '', key)
-
-                try:
                     hk.data[key] = ts
                 except TypeError:
                     all_types = set([type(x) for x in ts])

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -183,7 +183,7 @@ class Provider:
         * contains only letters (a-z, A-Z; case sensitive), decimal digits (0-9), and the
           underscore (_).
         * begins with a letter, or with any number of underscores followed by a letter.
-        * is no more than 255 characters long.
+        * is at least one, but no more than 255, character(s) long.
 
         Args:
             field_name (str):
@@ -195,8 +195,14 @@ class Provider:
                  through this method, and that should be checked.
 
         """
+        # check for empty string
+        if field_name == "":
+            new_field_name = "invalid_field"
+        else:
+            new_field_name = field_name
+
         # replace spaces with underscores
-        new_field_name = field_name.replace(' ', '_')
+        new_field_name = new_field_name.replace(' ', '_')
 
         # replace invalid characters
         new_field_name = re.sub('[^a-zA-Z0-9_]', '', new_field_name)
@@ -283,6 +289,11 @@ class Provider:
                     new_field_names = []
                     for field_name, field_values in block_dict['data'].items():
                         new_field_name = Provider._enforce_field_name_rules(field_name)
+
+                        # Catch instance where rule enforcement strips all characters
+                        if not new_field_name:
+                            new_field_name = Provider._enforce_field_name_rules("invalid_field_" + field_name)
+
                         new_field_name = Provider._check_for_duplicate_names(new_field_name,
                                                                              new_field_names)
 

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -225,9 +225,10 @@ class Provider:
         matches are found.
 
         The results of Provider._enforce_field_name_rules() are not guarenteed
-        to be unique. This method will check field_name against a list of field names
-        of existing field names and try to append '_N', with N being a zero
-        padded integer up to 99.
+        to be unique. This method will check field_name against a list of
+        existing field names and try to append '_N', with N being a zero padded
+        integer up to 99. Longer integers, though not expected to see use, are
+        also supported, though will not be zero padded.
 
         In the event the field name is at the maximum allowed length, we remove
         some characters before appending the additional underscore and integer.
@@ -247,18 +248,15 @@ class Provider:
             str: A new field name that is not already in name_list
 
         """
-        # Assume duplicate name, until proven otherwise
-        duplicate_name = True
         name_index = 1
 
-        while duplicate_name:
-            if field_name not in name_list:
-                duplicate_name = False
+        while field_name in name_list:
+            if len(field_name) < 252:
+                field_name += f'_{name_index:02}'
             else:
-                if len(field_name) < 252:
-                    field_name += f'_{name_index:02}'
-                else:
-                    field_name[:-3] += f'_{name_index:02}'
+                suffix = f'_{name_index:02}'
+                suf_len = len(suffix)
+                field_name = field_name[:-1*suf_len] + f'_{name_index:02}'
 
             name_index += 1
 

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -310,8 +310,8 @@ class Provider:
             >>> prov.save_to_block(data)
 
             Note the block name shows up twice, once as the dict key in the
-            outer data dictionary, and again under the 'block_name' value -- in
-            this instance both the word 'test'.
+            outer data dictionary, and again under the 'block_name' value.
+            These must match -- in this instance both the word 'test'.
 
         Args:
             data (dict): data dictionary from incoming data queue

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -257,12 +257,12 @@ class Provider:
         name_index = 1
 
         while field_name in name_list:
-            if len(field_name) < 252:
-                field_name += f'_{name_index:02}'
+            suffix = f'_{name_index:02}'
+            suf_len = len(suffix)
+            if len(field_name) < (255 - suf_len):
+                field_name += suffix
             else:
-                suffix = f'_{name_index:02}'
-                suf_len = len(suffix)
-                field_name = field_name[:-1*suf_len] + f'_{name_index:02}'
+                field_name = field_name[:-1*suf_len] + suffix
 
             name_index += 1
 

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -259,11 +259,7 @@ class Provider:
         while field_name in name_list:
             suffix = f'_{name_index:02}'
             suf_len = len(suffix)
-            if len(field_name) < (255 - suf_len):
-                field_name += suffix
-            else:
-                field_name = field_name[:-1*suf_len] + suffix
-
+            field_name = field_name[:255 - suf_len] + suffix
             name_index += 1
 
         return field_name

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -2,6 +2,7 @@ import os
 import datetime
 import binascii
 import time
+import re
 
 from typing import Dict
 
@@ -211,6 +212,14 @@ class Provider:
             hk.prefix = block.prefix
             hk.t = block.timestamps
             for key, ts in block.data.items():
+                try:
+                    ocs_feed.Feed.verify_data_field_string(key)
+                except ValueError:
+                    self.log.error("data field name {field} is " +
+                                   "invalid, removing invalid characters.",
+                                   field=key)
+                    key = re.sub('[^a-zA-Z0-9_]', '', key)
+
                 try:
                     hk.data[key] = ts
                 except TypeError:

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -290,7 +290,7 @@ class Feed:
         result = check_invalid.search(field)
         if result:
             raise ValueError("message 'data' block contains a key with the " +
-                             f"invalid charcter '{result.group(0)}'. "
+                             f"invalid character '{result.group(0)}'. "
                              "Valid characters are a-z, A-Z, 0-9, and underscore.")
 
         # check for non-letter start, even after underscores

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -266,7 +266,7 @@ class Feed:
         * contains only letters (a-z, A-Z; case sensitive), decimal digits (0-9), and the
           underscore (_).
         * begins with a letter, or with any number of underscores followed by a letter.
-        * is no more than 255 characters long.
+        * is at least one, but no more than 255, character(s) long.
 
         Args:
             field (str):
@@ -279,6 +279,11 @@ class Feed:
             ValueError: If field name is invalid.
 
         """
+        # Check for empty field name
+        if not field:
+            raise ValueError("Empty field name encountered, please enter " +
+                             "a valid field name.")
+
         # Complement (^) the set, matching any unlisted characters
         check_invalid = re.compile('[^a-zA-Z0-9_]')
 

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -261,6 +261,19 @@ class Feed:
         """There are strict rules for the characters allowed in field names.
         This function verifies the names in a message are valid.
 
+        Args:
+            message (dict):
+                Data to be published (see Feed.publish_message for details).
+
+        """
+        for k, v in message['data'].items():
+            Feed.verify_data_field_string(k)
+
+    @staticmethod
+    def verify_data_field_string(field):
+        """There are strict rules for the characters allowed in field names.
+        This function verifies the names in a message are valid.
+
         A valid name:
 
         – contains only letters (a-z, A-Z; case sensitive), decimal digits (0-9), and the
@@ -269,8 +282,14 @@ class Feed:
         – is no more than 255 characters long.
 
         Args:
-            message (dict):
-                Data to be published (see Feed.publish_message for details).
+            field (str):
+                Field name string to verify.
+
+        Returns:
+            bool: True if field name is valid.
+
+        Raises:
+            ValueError: If field name is invalid.
 
         """
         # Complement (^) the set, matching any unlisted characters
@@ -280,23 +299,23 @@ class Feed:
         # Leading ^ matches the start of string, so following numbers are valid
         check_start = re.compile('^[^a-zA-Z]')
 
-        for k, v in message['data'].items():
-            # check for invalid characters
-            result = check_invalid.search(k)
-            if result:
-                raise ValueError("message 'data' block contains a key with the " +
-                                 f"invalid charcter '{result.group(0)}'. "
-                                 "Valid characters are a-z, A-Z, 0-9, and underscore.")
+        # check for invalid characters
+        result = check_invalid.search(field)
+        if result:
+            raise ValueError("message 'data' block contains a key with the " +
+                             f"invalid charcter '{result.group(0)}'. "
+                             "Valid characters are a-z, A-Z, 0-9, and underscore.")
 
-            # check for non-letter after underscores
-            if k[0] == "_":
-                stripped_key = k.strip("_")
-                if check_start.search(stripped_key):
-                    raise ValueError(f"message 'data' block contains the key {k}, which " +
-                                     "does not start with a letter (after any number of " +
-                                     "leading underscores.)")
+        # check for non-letter start, even after underscores
+        stripped_key = field.strip("_")
+        if check_start.search(stripped_key):
+            raise ValueError(f"message 'data' block contains the key {field}, " +
+                             "which does not start with a letter (after any " +
+                             "number of leading underscores.)")
 
-            # check key length
-            if len(k) > 255:
-                raise ValueError(f"message 'data' block contains key {k} which " +
-                                 "exceeds the valid length of 255 characters.")
+        # check key length
+        if len(field) > 255:
+            raise ValueError(f"message 'data' block contains key {field} which " +
+                             "exceeds the valid length of 255 characters.")
+
+        return True

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -263,10 +263,10 @@ class Feed:
 
         A valid name:
 
-        – contains only letters (a-z, A-Z; case sensitive), decimal digits (0-9), and the
-        underscore (_).
-        – begins with a letter, or with any number of underscores followed by a letter.
-        – is no more than 255 characters long.
+        * contains only letters (a-z, A-Z; case sensitive), decimal digits (0-9), and the
+          underscore (_).
+        * begins with a letter, or with any number of underscores followed by a letter.
+        * is no more than 255 characters long.
 
         Args:
             field (str):

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -633,7 +633,7 @@ def register_agent_class(class_name, filename):
 def scan_for_agents(do_registration=True):
     """Identify and import ocs Agent plugin scripts.  This will find all
     modules in the current module search path (sys.path) that begin
-    with the name 'ocs_plugin_'.
+    with the name 'ocs_plugin\_'.
 
     Args:
         do_registration (bool): If True, the modules are imported,

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -109,9 +109,5 @@ def test_passing_invalid_data_field_name():
            }
     provider.save_to_block(data)
 
-    # Dummy HKSessionHelper
-    sess = so3g.hk.HKSessionHelper(description="testing")
-    sess.start_time = time.time()
-    sess.session_id = 'test_sessid'
-
-    provider.to_frame(hksess=sess)
+    assert 'invalidkey' in provider.blocks['test'].data.keys()
+    assert 'invalid.key' not in provider.blocks['test'].data.keys()

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -111,3 +111,26 @@ def test_passing_invalid_data_field_name():
 
     assert 'invalidkey' in provider.blocks['test'].data.keys()
     assert 'invalid.key' not in provider.blocks['test'].data.keys()
+
+def test_passing_too_long_data_field_name():
+    """Invalid data field names should get caught by the Feed, however, we
+    check for them in the Aggregator as well.
+
+    The aggregator will catch the error, but remove invalid characters from the
+    string.
+
+    This tests passing too long of a field name, which should get truncated.
+
+    """
+    # Dummy Provider for testing
+    provider = Provider('test_provider', 'test_sessid', 3, 1)
+    provider.frame_start_time = time.time()
+    data = {'test': {'block_name': 'test',
+                     'timestamps': [time.time()],
+                     'data': {'a'*1000: [1],
+                              'key2': ['a']},
+                     'prefix': ''}
+           }
+    provider.save_to_block(data)
+
+    assert 'a'*255 in provider.blocks['test'].data.keys()

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -90,7 +90,7 @@ def test_data_type_in_provider_save_to_block():
     provider.save_to_block(data)
 
 # 'data' field names
-def test_passing_invalid_data_field_name():
+def test_passing_invalid_data_field_name1():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
 
@@ -111,6 +111,28 @@ def test_passing_invalid_data_field_name():
 
     assert 'invalidkey' in provider.blocks['test'].data.keys()
     assert 'invalid.key' not in provider.blocks['test'].data.keys()
+
+def test_passing_invalid_data_field_name2():
+    """Invalid data field names should get caught by the Feed, however, we
+    check for them in the Aggregator as well.
+
+    The aggregator will catch the error, but remove invalid characters from the
+    string.
+
+    """
+    # Dummy Provider for testing
+    provider = Provider('test_provider', 'test_sessid', 3, 1)
+    provider.frame_start_time = time.time()
+    data = {'test': {'block_name': 'test',
+                     'timestamps': [time.time()],
+                     'data': {'__123invalid.key': [1],
+                              'key2': ['a']},
+                     'prefix': ''}
+           }
+    provider.save_to_block(data)
+
+    assert '__invalidkey' in provider.blocks['test'].data.keys()
+    assert '__123invalid.key' not in provider.blocks['test'].data.keys()
 
 def test_passing_too_long_data_field_name():
     """Invalid data field names should get caught by the Feed, however, we

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -183,3 +183,24 @@ def test_reducing_to_duplicate_field_names():
     # More specifically, they should be these keys
     assert 'aninvalidkey' in provider.blocks['test'].data.keys()
     assert 'aninvalidkey_01' in provider.blocks['test'].data.keys()
+
+def test_space_replacement_in_field_names():
+    """Invalid data field names should get caught by the Feed, however, we
+    check for them in the Aggregator as well.
+
+    Spaces should be replaced by underscores.
+
+    """
+    # Dummy Provider for testing
+    provider = Provider('test_provider', 'test_sessid', 3, 1)
+    provider.frame_start_time = time.time()
+    data = {'test': {'block_name': 'test',
+                     'timestamps': [time.time()],
+                     'data': {'_an invalid key': [1],
+                              'key2': ['a']},
+                     'prefix': ''}
+           }
+    provider.save_to_block(data)
+
+    assert '_an_invalid_key' in provider.blocks['test'].data.keys()
+    assert 'key2' in provider.blocks['test'].data.keys()

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -157,6 +157,30 @@ def test_passing_too_long_data_field_name():
 
     assert 'a'*255 in provider.blocks['test'].data.keys()
 
+def test_long_duplicate_name():
+    """Invalid data field names should get caught by the Feed, however, we
+    check for them in the Aggregator as well.
+
+    The aggregator will catch the error, but remove invalid characters from the
+    string.
+
+    This tests passing two long and eventually duplicated names.
+
+    """
+    # Dummy Provider for testing
+    provider = Provider('test_provider', 'test_sessid', 3, 1)
+    provider.frame_start_time = time.time()
+    data = {'test': {'block_name': 'test',
+                     'timestamps': [time.time()],
+                     'data': {'a'*1000: [1],
+                              'a'*1001: ['a']},
+                     'prefix': ''}
+           }
+    provider.save_to_block(data)
+
+    assert 'a'*255 in provider.blocks['test'].data.keys()
+    assert 'a'*252 + '_01' in provider.blocks['test'].data.keys()
+
 def test_reducing_to_duplicate_field_names():
     """Invalid data field names get modified by the Aggregator to comply with
     the set rules. This can result in duplicate field names under certain

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -88,3 +88,30 @@ def test_data_type_in_provider_write():
                      'prefix': ''}
            }
     provider.write(data)
+
+# 'data' field names
+def test_passing_invalid_data_field_name():
+    """Invalid data field names should get caught by the Feed, however, we
+    check for them in the Aggregator as well.
+
+    The aggregator will catch the error, but remove invalid characters from the
+    string.
+
+    """
+    # Dummy Provider for testing
+    provider = Provider('test_provider', 'test_sessid', 3, 1)
+    provider.frame_start_time = time.time()
+    data = {'test': {'block_name': 'test',
+                     'timestamps': [time.time()],
+                     'data': {'invalid.key': [1],
+                              'key2': ['a']},
+                     'prefix': ''}
+           }
+    provider.write(data)
+
+    # Dummy HKSessionHelper
+    sess = so3g.hk.HKSessionHelper(description="testing")
+    sess.start_time = time.time()
+    sess.session_id = 'test_sessid'
+
+    provider.to_frame(hksess=sess)

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -156,3 +156,30 @@ def test_passing_too_long_data_field_name():
     provider.save_to_block(data)
 
     assert 'a'*255 in provider.blocks['test'].data.keys()
+
+def test_reducing_to_duplicate_field_names():
+    """Invalid data field names get modified by the Aggregator to comply with
+    the set rules. This can result in duplicate field names under certain
+    conditions.
+
+    This tests passing two invalid field names, which might naively get
+    modified to be identical.
+
+    """
+    # Dummy Provider for testing
+    provider = Provider('test_provider', 'test_sessid', 3, 1)
+    provider.frame_start_time = time.time()
+    data = {'test': {'block_name': 'test',
+                     'timestamps': [time.time()],
+                     'data': {'an.invalid.key#': [1],
+                              'an.invalid.key%': ['a']},
+                     'prefix': ''}
+           }
+    provider.save_to_block(data)
+
+    # Should still be two keys, i.e. one didn't overwrite the other
+    assert len(provider.blocks['test'].data.keys()) == 2
+
+    # More specifically, they should be these keys
+    assert 'aninvalidkey' in provider.blocks['test'].data.keys()
+    assert 'aninvalidkey_01' in provider.blocks['test'].data.keys()

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -228,3 +228,45 @@ def test_space_replacement_in_field_names():
 
     assert '_an_invalid_key' in provider.blocks['test'].data.keys()
     assert 'key2' in provider.blocks['test'].data.keys()
+
+def test_empty_field_name():
+    """Invalid data field names should get caught by the Feed, however, we
+    check for them in the Aggregator as well.
+
+    A blank string should be invalid.
+
+    """
+    # Dummy Provider for testing
+    provider = Provider('test_provider', 'test_sessid', 3, 1)
+    provider.frame_start_time = time.time()
+    data = {'test': {'block_name': 'test',
+                     'timestamps': [time.time()],
+                     'data': {'': [1],
+                              'key2': ['a']},
+                     'prefix': ''}
+           }
+    provider.save_to_block(data)
+
+    assert '' not in provider.blocks['test'].data.keys()
+
+def test_enforced_field_which_becomes_empty():
+    """Invalid data field names should get caught by the Feed, however, we
+    check for them in the Aggregator as well.
+
+    A totally invalid field will have all characters stripped from it, which is
+    again an invalid field.
+
+    """
+    # Dummy Provider for testing
+    provider = Provider('test_provider', 'test_sessid', 3, 1)
+    provider.frame_start_time = time.time()
+    data = {'test': {'block_name': 'test',
+                     'timestamps': [time.time()],
+                     'data': {'123': [1],
+                              'key2': ['a']},
+                     'prefix': ''}
+           }
+    provider.save_to_block(data)
+
+    assert '' not in provider.blocks['test'].data.keys()
+    assert 'invalid_field_123' in provider.blocks['test'].data.keys()

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -18,7 +18,7 @@ def test_passing_float_in_provider_to_frame():
                               'key2': [2]},
                      'prefix': ''}
            }
-    provider.write(data)
+    provider.save_to_block(data)
 
     # Dummy HKSessionHelper
     sess = so3g.hk.HKSessionHelper(description="testing")
@@ -42,7 +42,7 @@ def test_passing_float_like_str_in_provider_to_frame():
                               'key2': ['1', 2]},
                      'prefix': ''}
            }
-    provider.write(data)
+    provider.save_to_block(data)
 
     # Dummy HKSessionHelper
     sess = so3g.hk.HKSessionHelper(description="testing")
@@ -67,7 +67,7 @@ def test_passing_non_float_like_str_in_provider_to_frame():
                               'key2': ['a']},
                      'prefix': ''}
            }
-    provider.write(data)
+    provider.save_to_block(data)
 
     # Dummy HKSessionHelper
     sess = so3g.hk.HKSessionHelper(description="testing")
@@ -78,7 +78,7 @@ def test_passing_non_float_like_str_in_provider_to_frame():
 
 # This is perhaps another problem, I'm passing irregular length data sets and
 # it's not raising any sort of alarm. How does this get handled?
-def test_data_type_in_provider_write():
+def test_data_type_in_provider_save_to_block():
     provider = Provider('test_provider', 'test_sessid', 3, 1)
     provider.frame_start_time = time.time()
     data = {'test': {'block_name': 'test',
@@ -87,7 +87,7 @@ def test_data_type_in_provider_write():
                               'key2': ['1', 1]},
                      'prefix': ''}
            }
-    provider.write(data)
+    provider.save_to_block(data)
 
 # 'data' field names
 def test_passing_invalid_data_field_name():
@@ -107,7 +107,7 @@ def test_passing_invalid_data_field_name():
                               'key2': ['a']},
                      'prefix': ''}
            }
-    provider.write(data)
+    provider.save_to_block(data)
 
     # Dummy HKSessionHelper
     sess = so3g.hk.HKSessionHelper(description="testing")

--- a/tests/test_ocs_feed.py
+++ b/tests/test_ocs_feed.py
@@ -86,6 +86,128 @@ class TestPublishMessage:
         with pytest.raises(TypeError):
             test_feed.publish_message(test_message)
 
+    def test_invalid_data_key_character(self):
+        """Passing disallowed characters in a field key should result in a
+        ValueError upon publishing.
+
+        """
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        test_message = {
+            'block_name': 'test',
+            'timestamp': time.time(),
+            'data': {
+                'invalid.key1': 1.,
+                'valid_key2': 1.,
+            }
+        }
+
+        with pytest.raises(ValueError):
+            test_feed.publish_message(test_message)
+
+    def test_data_key_too_long(self):
+        """Passing a data key that exceeds 255 characters should raise a 
+        ValueError upon publishing.
+
+        """
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        test_message = {
+            'block_name': 'test',
+            'timestamp': time.time(),
+            'data': {
+                'a'*256: 1.,
+                'valid_key2': 1.,
+            }
+        }
+
+        with pytest.raises(ValueError):
+            test_feed.publish_message(test_message)
+
+    def test_data_key_start_underscore1(self):
+        """Data keys can start with any number of _'s followed by a letter.
+        Test several cases where we start with underscores.
+
+        """
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        # Valid underscore + letter start
+        test_message = {
+            'block_name': 'test',
+            'timestamp': time.time(),
+            'data': {
+                '_valid': 1.,
+                'valid_key2': 1.,
+            }
+        }
+
+        test_feed.publish_message(test_message)
+
+    def test_data_key_start_underscore2(self):
+        """Data keys can start with any number of _'s followed by a letter.
+        Test several cases where we start with underscores.
+
+        """
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        # Valid multi-underscore + letter start
+        test_message = {
+            'block_name': 'test',
+            'timestamp': time.time(),
+            'data': {
+                '____valid1': 1.,
+                'valid_key2': 1.,
+            }
+        }
+
+        test_feed.publish_message(test_message)
+
+    def test_data_key_start_underscore3(self):
+        """Data keys can start with any number of _'s followed by a letter.
+        Test several cases where we start with underscores.
+
+        """
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        # Invalid underscore + number start
+        test_message = {
+            'block_name': 'test',
+            'timestamp': time.time(),
+            'data': {
+                '_1valid': 1.,
+                'valid_key2': 1.,
+            }
+        }
+
+        with pytest.raises(ValueError):
+            test_feed.publish_message(test_message)
+
+    def test_data_key_start_underscore4(self):
+        """Data keys can start with any number of _'s followed by a letter.
+        Test several cases where we start with underscores.
+
+        """
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        # Invalid multi-underscore + number start
+        test_message = {
+            'block_name': 'test',
+            'timestamp': time.time(),
+            'data': {
+                '____1valid': 1.,
+                'valid_key2': 1.,
+            }
+        }
+
+        with pytest.raises(ValueError):
+            test_feed.publish_message(test_message)
+
 
 # ocs_feed.Block
 def test_block_creation():

--- a/tests/test_ocs_feed.py
+++ b/tests/test_ocs_feed.py
@@ -106,6 +106,25 @@ class TestPublishMessage:
         with pytest.raises(ValueError):
             test_feed.publish_message(test_message)
 
+    def test_data_key_start_with_number(self):
+        """Field names should start with a letter.
+
+        """
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        test_message = {
+            'block_name': 'test',
+            'timestamp': time.time(),
+            'data': {
+                '1invalidkey': 1.,
+                'valid_key2': 1.,
+            }
+        }
+
+        with pytest.raises(ValueError):
+            test_feed.publish_message(test_message)
+
     def test_data_key_too_long(self):
         """Passing a data key that exceeds 255 characters should raise a 
         ValueError upon publishing.

--- a/tests/test_ocs_feed.py
+++ b/tests/test_ocs_feed.py
@@ -227,6 +227,25 @@ class TestPublishMessage:
         with pytest.raises(ValueError):
             test_feed.publish_message(test_message)
 
+    def test_empty_field_name(self):
+        """Check for empty string as a field name.
+
+        """
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        # Invalid multi-underscore + number start
+        test_message = {
+            'block_name': 'test',
+            'timestamp': time.time(),
+            'data': {
+                '': 1.,
+                'valid_key2': 1.,
+            }
+        }
+
+        with pytest.raises(ValueError):
+            test_feed.publish_message(test_message)
 
 # ocs_feed.Block
 def test_block_creation():


### PR DESCRIPTION
This PR is to address #130.

We add a field name validation method to the Feed class and use it to raise an error when an Agent publishes data with an invalid field name. This should get the attention of developers if they happen to choose an invalid field name.

Since we were already looping over the contents of the message, we change our type checking method slightly to accommodate checking fields at the same time.

The Aggregator uses the same validation method to check for invalid names. While invalid names shouldn't even make it to the Aggregator now, we check nonetheless. Since we don't want the aggregator to crash or write invalid fields to disk our two options are:
* drop the invalid fields
* try to fix the fields

I opted for fixing the fields, so we remove invalid characters from fields if we see them at the Aggregator, but again, we shouldn't see them. We log an error if we do. This involved rebuilding the data message before building the Block structure when needed.

There are several accompanying tests, mostly for the Feed.