### PR TITLE
Bump so3g version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # A container setup with an installation of ocs.
 
 # Use ubuntu base image
-FROM simonsobs/so3g:v0.0.7-21-g79e6902
+FROM simonsobs/so3g:v0.0.7-51-ga0a6cf6
 
 # Set locale
 ENV LANG C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # A container setup with an installation of ocs.
 
 # Use ubuntu base image
-FROM simonsobs/so3g:v0.0.7-66-g97b0a9f
+FROM simonsobs/so3g:v0.0.8
 
 # Set locale
 ENV LANG C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # A container setup with an installation of ocs.
 
 # Use ubuntu base image
-FROM simonsobs/so3g:v0.0.7-51-ga0a6cf6
+FROM simonsobs/so3g:v0.0.7-66-g97b0a9f
 
 # Set locale
 ENV LANG C.UTF-8


### PR DESCRIPTION
This introduces support for HK format v1 to the ocs image.

(This is done in two commits just because of an old testing commit I pushed to this branch. Will squash and merge when tests on the latest pass.)