### PR TITLE
Added sotodlib installation to ocs-util

### DIFF
--- a/docker/ocs-util/Dockerfile
+++ b/docker/ocs-util/Dockerfile
@@ -3,6 +3,9 @@ FROM ocs:latest
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt
 
+COPY setup_sotodlib.sh /tmp/setup_sotodlib.sh
+RUN sh /tmp/setup_sotodlib.sh
+
 USER ocs:ocs
 
 ENV JUPYTER_CONFIG_DIR /home/ocs/.jupyter

--- a/docker/ocs-util/requirements.txt
+++ b/docker/ocs-util/requirements.txt
@@ -1,2 +1,9 @@
-
 jupyter
+scipy
+
+# Requirements for sotodlib
+quaternionarray
+toml
+
+# Requirement for sotoddb
+h5py 

--- a/docker/ocs-util/setup_sotodlib.sh
+++ b/docker/ocs-util/setup_sotodlib.sh
@@ -1,0 +1,14 @@
+cd /app_lib
+
+git clone https://github.com/simonsobs/sotoddb.git
+git clone https://github.com/simonsobs/sotodlib.git
+
+# Installs sotoddb. Will take this out when it's no longer needed
+cd sotoddb
+echo "Installing sotoddb..."
+pip3 install .
+
+cd /app_lib/sotodlib
+echo "Installing sotodlib..."
+git checkout tags/v0.3.0
+pip3 install -e .


### PR DESCRIPTION
This PR adds sotodlib to the ocs-util docker, resolving #141. 

I realize that some things such as requiring `sotoddb` will be phased out, but I think this will be really helpful in the short-term, so I think we should merge this and then remove `sotoddb` once that's merged into `sotodlib`.