### PR TITLE
Migrate docker builds to GitHub Actions and establish contributing guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, tests ran to see how -->
+<!--- your change affects other areas of the code, etc. -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,43 @@
+name: Build Develop Images
+
+on:
+  push:
+    # TODO: remove github-actions-docker branch after testing
+    branches: [ develop, github-actions-docker ]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+      # Fetch all history for all tags and branches
+      with:
+        fetch-depth: 0
+
+    # Test
+    - name: Build docker images
+      run: |
+        docker-compose build
+
+    - name: Test with pytest wtihin a docker container
+      run: |
+        docker run -v $PWD:/coverage --rm ocs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest -p no:wampy --cov /app/ocs/ocs/ ./tests/"
+
+    # Dockerize
+    - name: Build and push development docker image
+      env:
+        REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
+        DOCKERHUB_ORG: "simonsobs"
+      run: |
+        export DOCKER_TAG=dev-`git describe --tags --always`
+        echo "${DOCKER_TAG}"
+        echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USER}" --password-stdin;
+
+        # Tag all images for upload to the registry
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+
+        # Upload to docker registry
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${DOCKERHUB_ORG}/{}:${DOCKER_TAG} pushed

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         docker-compose build
 
-    - name: Test with pytest wtihin a docker container
+    - name: Test with pytest within a docker container
       run: |
         docker run -v $PWD:/coverage --rm ocs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest -p no:wampy --cov /app/ocs/ocs/ ./tests/"
 

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -2,8 +2,7 @@ name: Build Develop Images
 
 on:
   push:
-    # TODO: remove github-actions-docker branch after testing
-    branches: [ develop, github-actions-docker ]
+    branches: [ develop ]
 
 jobs:
   build:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -31,7 +31,7 @@ jobs:
         REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
         DOCKERHUB_ORG: "simonsobs"
       run: |
-        export DOCKER_TAG=dev-`git describe --tags --always`
+        export DOCKER_TAG=`git describe --tags --always`-dev
         echo "${DOCKER_TAG}"
         echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USER}" --password-stdin;
 

--- a/.github/workflows/official-docker-images.yml
+++ b/.github/workflows/official-docker-images.yml
@@ -1,0 +1,43 @@
+name: Build Official Docker Images
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      # Fetch all history for all tags and branches
+      with:
+        fetch-depth: 0
+
+    # Test
+    - name: Build docker images
+      run: |
+        docker-compose build
+
+    - name: Test with pytest wtihin a docker container
+      run: |
+        docker run -v $PWD:/coverage --rm ocs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest -p no:wampy --cov /app/ocs/ocs/ ./tests/"
+
+    # Dockerize
+    - name: Build and push official docker image
+      env:
+        REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
+        DOCKERHUB_ORG: "simonsobs"
+      run: |
+        export DOCKER_TAG=`git describe --tags --always`
+        echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USER}" --password-stdin;
+
+        # Tag all images for upload to the registry
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:latest
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+
+        # Upload to docker registry
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:latest
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}
+        docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${DOCKERHUB_ORG}/{}:${DOCKER_TAG} pushed

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ python:
 
 stages:
   - test
-  - name: dockerize
-    if: |
-      branch = master AND \
-      type = push
 
 jobs:
   include:
@@ -37,26 +33,3 @@ jobs:
 
         # Publish results to coveralls
         - coveralls
-
-    - stage: dockerize
-      install: true
-
-      before_script:
-        # Use the git tag to tag docker image
-        - export DOCKER_TAG=`git describe --tags --always`
-        # Login to docker
-        - echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USER}" --password-stdin;
-
-      script:
-        # Build the docker images with docker-compose
-        - docker-compose build
-
-      after_success:
-        # Tag all images for upload to the registry
-        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:latest"
-        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}"
-
-        # Upload to docker registry
-        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:${DOCKER_TAG}"
-        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${DOCKERHUB_ORG}/{}:latest"
-        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${DOCKERHUB_ORG}/{}:${DOCKER_TAG} pushed"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,48 @@
+===================
+Contributing to OCS
+===================
+
+Branches
+--------
+
+There are two long-lived branches in OCS, ``master`` and ``develop``.
+``master`` should be considered stable, and will only move forward on official
+releases. ``develop`` may be unstable, and is where all development should take
+place.
+
+What this means for you, the contributor, is that you should base your feature
+branches off of the latest ``develop`` branch, and pull request them into
+``develop``. Detailed steps below.
+
+Pull Requests
+-------------
+
+When opening a pull request, you should push your feature branch, and select
+the ``develop`` branch as the base branch, the branch you want to merge your
+feature branch into.
+
+Releases
+--------
+
+If you are trying to issue a release of OCS you should follow these steps:
+
+1. Open a Pull Request, comparing ``develop`` to the ``master`` base branch.
+   Describe the features added for this release.
+2. Make a merge commit when you merge this PR.
+    * This merge commit will be what is tagged for the release.
+    * ``develop`` is now one commit behind ``master`` (the merge commit)
+3. Pull the latest ``master`` and ``develop`` branches to your work station.
+4. Checkout ``develop``, then run ``git merge --ff-only master``, catching ``develop`` up to ``master``.
+5. ``push origin develop`` to update the remote ``develop`` branch.
+
+The ``develop`` and ``master`` branches are now aligned, and ``master`` is
+ready to be released. You can use the GitHub release interface to create a new
+release, copying the change log you wrote in the PR and otherwise describing the
+release.
+
+Development Guide
+-----------------
+
+Contributors should follow the recommendations made in the `SO Developer Guide`_.
+
+.. _SO Developer Guide: https://simons1.princeton.edu/docs/so_dev_guide/html/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,13 +24,18 @@ feature branch into.
 Releases
 --------
 
+.. note::
+    Releases will be issued by core maintainers of OCS.
+
 If you are trying to issue a release of OCS you should follow these steps:
 
 1. Open a Pull Request, comparing ``develop`` to the ``master`` base branch.
    Describe the features added for this release.
 2. Make a merge commit when you merge this PR.
+
     * This merge commit will be what is tagged for the release.
     * ``develop`` is now one commit behind ``master`` (the merge commit)
+
 3. Pull the latest ``master`` and ``develop`` branches to your work station.
 4. Checkout ``develop``, then run ``git merge --ff-only master``, catching ``develop`` up to ``master``.
 5. ``push origin develop`` to update the remote ``develop`` branch.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,8 +24,7 @@ feature branch into.
 Releases
 --------
 
-.. note::
-    Releases will be issued by core maintainers of OCS.
+    **Note:** Releases will be issued by core maintainers of OCS.
 
 If you are trying to issue a release of OCS you should follow these steps:
 
@@ -33,8 +32,8 @@ If you are trying to issue a release of OCS you should follow these steps:
    Describe the features added for this release.
 2. Make a merge commit when you merge this PR.
 
-    * This merge commit will be what is tagged for the release.
-    * ``develop`` is now one commit behind ``master`` (the merge commit)
+   * This merge commit will be what is tagged for the release.
+   * ``develop`` is now one commit behind ``master`` (the merge commit)
 
 3. Pull the latest ``master`` and ``develop`` branches to your work station.
 4. Checkout ``develop``, then run ``git merge --ff-only master``, catching ``develop`` up to ``master``.

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,9 @@ OCS - Observatory Control System
 .. image:: https://coveralls.io/repos/github/simonsobs/ocs/badge.svg
     :target: https://coveralls.io/github/simonsobs/ocs
 
+.. image:: https://img.shields.io/badge/dockerhub-latest-blue
+    :target: https://hub.docker.com/r/simonsobs/ocs/tags
+
 Overview
 --------
 
@@ -30,13 +33,12 @@ user to perform a series of unattended, interlocking data acquisition tasks.
 This repository, `OCS`_, contains library code and core system
 components.  Additional code for operating specific hardware can be
 found in the `Simons Observatory Control System (SOCS)`_ repository.
-The time-domain data query system, with grafana integration, is
-provided through `Sisock`_.
+Grafana and InfluxDB are supported to provide a near real-time monitoring and
+historical look back of the housekeeping data.
 
 .. _crossbar.io: http://crossbario.com
 .. _`OCS`: https://github.com/simonsobs/ocs/
 .. _`Simons Observatory Control System (SOCS)`: https://github.com/simonsobs/socs/
-.. _`SiSock`: https://github.com/simonsobs/sisock/
 
 Dependencies
 ------------
@@ -66,6 +68,21 @@ other software you are working with. See the latest `tags`_.
 
 .. _tags: https://github.com/simonsobs/ocs/tags
 
+Docker Images
+-------------
+Docker images for OCS and each Agent are available on `Docker Hub`_. Official
+releases will be tagged with their release version, i.e. ``v0.1.0``. These are
+only built on release, and the ``latest`` tag will point to the latest of these
+released tags. These should be considered stable.
+
+Development images will be tagged with the latest released version tag, the
+number of commits ahead of that release, the latest commit hash, and the tag
+``-dev``, i.e.  ``v0.6.0-53-g0e390f6-dev``. These get built on each commit to
+the ``develop`` branch, and are useful for testing and development, but should
+be considered unstable.
+
+.. _Docker Hub: https://hub.docker.com/u/simonsobs
+
 Documentation
 -------------
 The OCS documentation can be built using sphinx once you have performed the
@@ -75,8 +92,9 @@ installation::
   make html
 
 You can then open ``docs/_build/html/index.html`` in your preferred web
-browser.
+browser. You can also find a copy hosted on `Read the Docs`_.
 
+.. _Read the Docs: https://ocs.readthedocs.io/en/latest/
 
 Example
 -------

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,12 @@ in that directory for details.
 .. _example/miniobs/: example/miniobs/
 .. _readme: example/miniobs/README.rst
 
+Contributing
+------------
+For guidelines on how to contribute to OCS see `CONTRIBUTING.rst`_.
+
+.. _CONTRIBUTING.rst: CONTRIBUTING.rst
+
 License
 --------
 This project is licensed under the BSD 2-Clause License - see the


### PR DESCRIPTION
This PR establishes the workflow we discussed a few OCS calls ago, namely it:
* Introduces the long lived `develop` branch
* Moves the publishing of docker images from Travis CI to GitHub Actions
* Splits this publishing of images into two different workflows:
    1. A develop workflow which builds and pushes `-dev` tagged images to Docker Hub on pushes to the `develop` branch. This allows testing of actively developed images prior to official releases.
    2. An official release workflow, triggered only on GitHub releases. This builds the official images that users should use in production environments.
* Describes this workflow and how to make a release in the new Contributing file
* Creates a PR template based on templates from [here](https://github.com/stevemao/github-issue-templates), the motivation being to check the users are following the workflow appropriately, i.e. PRing onto the develop branch. Other common template content also seems beneficial, so I've kept it.

The tests are still run on Travis CI for now, porting the code coverage tool has some subtle tricks to it that I need to figure out, but the big thing is getting the docker build workflow in place. Tests are still run in both new workflows.

Once things are approved I'll adopt the same workflow in socs with similar, if not identical, files.