### PR TITLE
Influx publisher updates

### DIFF
--- a/docs/agents/influxdb_publisher.rst
+++ b/docs/agents/influxdb_publisher.rst
@@ -18,7 +18,8 @@ Add an InfluxDBAgent to your OCS configuration file::
        'instance-id': 'influxagent',
        'arguments': [['--initial-state', 'record'],
                      ['--host', 'influxdb'],
-                     ['--port', 8086]]},
+                     ['--port', 8086],
+                     ['--database', 'ocs_feeds']]},
 
 docker-compose Configuration
 ----------------------------
@@ -72,12 +73,13 @@ Grafana Configuration
 Once your InfluxDB container and publisher are configured and running you will
 need to create an InfluxDB data source in Grafana. To do so, we add an InfluxDB
 data source with the URL ``http://influxdb:8086``, and the Database
-"ocs_feeds". The Name of the Data Source is up to you, in this example we set
-it to "OCS Feeds".
+(default "ocs_feeds", but this can be customized in your OCS config file.) The
+Name of the Data Source is up to you, in this example we set it to "OCS Feeds".
 
 .. note::
-    The "ocs_feeds" database will not exist until the first time the InfluxDB
-    Publisher Agent has successfully connected to the InfluxDB.
+    The "ocs_feeds" database (or whatever you choose to name the database) will
+    not exist until the first time the InfluxDB Publisher Agent has successfully
+    connected to the InfluxDB.
 
 .. image:: ../_static/grafana_influxdb_data_source.jpg
 


### PR DESCRIPTION
## Description
Address two items related to the InfluxDB Publisher:
1. Fix #113 
2. Allow user configurable database name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously we defaulted to the hard coded 'ocs_feeds' database name. There has only ever been one database, and setting the name wasn't initially important. Enabling user configurable database names allows users to re-upload data from .g3 files to a separate database instance, for instance if some reprocessing of data on disk needs to take place (see https://github.com/simonsobs/socs/pull/87).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
An isolated set of Docker containers containing core OCS components was run, first with the InfluxDB offline, checking for the reconnection attempts. Bringing the InfluxDB online then allows for successful reconnection and proceeding data publication (tested with an LS240 simulator.)

The same set of containers was then configured to publish data to a separate database, not the default 'ocs_feeds'. The new database was created and data successfully published to it.

The stack was brought up again and verified data published after fixing the flake8 errors as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
