### PR TITLE
Fix parsing for files with no feeds

### DIFF
--- a/bin/g32influx
+++ b/bin/g32influx
@@ -209,7 +209,7 @@ class DataLoader:
         """
         c = self.sqliteconn.cursor()
 
-        for f in self._file_list:
+        for f in tqdm(self._file_list, desc="Updating Database"):
             md5 = _md5sum(f)
             c.execute("SELECT * from g3files WHERE md5sum=?", (md5, ))
             result = c.fetchone()
@@ -265,14 +265,17 @@ class DataLoader:
         to_publish = c.fetchall()
 
         for path, chksum in tqdm(to_publish, desc="All Files"):
-            rval = self._publish_file(path)
-            if rval == 0:
-                c.execute("UPDATE g3files SET published=1 WHERE md5sum=?",
-                          (chksum, ))
+            if path in self._file_list:
+                rval = self._publish_file(path)
+                if rval == 0:
+                    c.execute("UPDATE g3files SET published=1 WHERE md5sum=?",
+                              (chksum, ))
+                else:
+                    c.execute("UPDATE g3files SET published=? WHERE md5sum=?",
+                              (rval, chksum))
+                self.sqliteconn.commit()
             else:
-                c.execute("UPDATE g3files SET published=? WHERE md5sum=?",
-                          (rval, chksum))
-            self.sqliteconn.commit()
+                logging.debug(f"Unpublished file {path} not in file_list, skipping.")
 
     def run(self):
         self.check_filelist_against_sqlite()
@@ -393,14 +396,22 @@ class SingleFileScanner:
         field = timeline["field"]
 
         # Do some good, ol' fashioned parsing.
-        s = field[0].split(".feeds.")
-        agent_address = s[0]
-        if " " in agent_address:
-            raise ValueError(f"Space contained in OCS address {s[0]}.")
-        # ff = field[0].split(".feeds.")[1]
-        feed_val = s[1].split(".")[0].replace(" ", "\ ")
-        field_tag = [f.split(".feeds.")[1].split(".")[1].replace(" ", "\ ")
-                     for f in field]
+        if ".feeds." not in field[0]:
+            split = field[0].split('.')
+            address = split[:-1]  # drop the channel name
+            agent_address = '.'.join(address)
+            feed_val = None  # feeds not included
+            field_tag = [f.split('.')[-1] for f in field]
+
+        else:
+            s = field[0].split(".feeds.")
+            agent_address = s[0]
+            if " " in agent_address:
+                raise ValueError(f"Space contained in OCS address {s[0]}.")
+            # ff = field[0].split(".feeds.")[1]
+            feed_val = s[1].split(".")[0].replace(" ", "\ ")
+            field_tag = [f.split(".feeds.")[1].split(".")[1].replace(" ", "\ ")
+                         for f in field]
 
         # Get the data. Since all the fields belong to the same timeline, their
         # timestamps are all the same object, which we can just grab from the
@@ -415,8 +426,13 @@ class SingleFileScanner:
         for _t, _data in zip(t, data):
             flist = ",".join(["%s=%s" % (_f, _d)
                               for _f, _d in zip(field_tag, _data)])
-            line.append("%s,feed=%s %s %d\n" %
-                        (agent_address, feed_val, flist, _t * 1e9))
+            if feed_val is not None:
+                line.append("%s,feed=%s %s %d\n" %
+                            (agent_address, feed_val, flist, _t * 1e9))
+            else:
+                line.append("%s %s %d\n" %
+                            (agent_address, flist, _t * 1e9))
+
         return line
 
     def publish_file(self, batch_size=100000):
@@ -452,7 +468,7 @@ class SingleFileScanner:
                                      batch_size=batch_size,
                                      protocol="line")
             except InfluxDBClientError as e:
-                logging.error(f"ERROR in {self.file}")
+                logging.error(f"ERROR in {self.path}")
                 logging.error(f"client error, likely a type error: {e}")
                 logging.debug(f"payload: {payload}")
                 return_value = 2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Older files might not have a "feeds.NAME" in the agent address, which breaks
some of the parsing here. This will now upload data without the feeds tags that
are now present.

This isn't a huge deal breaker, as most (all?) agents just use one feed at this
time. All past data will be returned if the feed tag is left off of InfluxDB
queries.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While running `g32influx` on the entire, recently reprocessed, Yale HK dataset I found some older files were causing the script to fail for the above reasons. This fixes the parsing errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The implemented changes were used to upload the entire Yale HK dataset to InfluxDB. The results look sensible so far.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
