### PR TITLE
g32influx bug fix and file check skip

### DIFF
--- a/bin/g32influx
+++ b/bin/g32influx
@@ -480,7 +480,7 @@ class SingleFileScanner:
             self.scan_file()
         except Exception:
             logging.error("Unable to read %s, likely due to old sog3 format."
-                          % self.basename)
+                          % self.path)
             return 2
         pub_ret = self.publish_file()
 

--- a/bin/g32influx
+++ b/bin/g32influx
@@ -277,8 +277,19 @@ class DataLoader:
             else:
                 logging.debug(f"Unpublished file {path} not in file_list, skipping.")
 
-    def run(self):
-        self.check_filelist_against_sqlite()
+    def run(self, skip_file_check=False):
+        """Run file check and upload.
+
+        Parameters
+        ----------
+        skip_file_check : bool
+            Skip the file check step, proccessing only files already in the
+            database from a previous scan. Helpful if restarting a run where
+            you know input files haven't changed.
+
+        """
+        if not skip_file_check:
+            self.check_filelist_against_sqlite()
         self.publish_all_files_to_influxdb()
 
 
@@ -501,6 +512,8 @@ def main():
                         help='Set loglevel.')
     parser.add_argument('--logfile', '-f', default='g32influx.log',
                         help='Set the logfile.')
+    parser.add_argument('--skip-file-check', '-s', action='store_true',
+                        help='Skip file check step.')
     # parser.add_argument('--docker', '-d', action='store_true',
     #                     help='Force use of docker, even if so3g is installed.')
     args = parser.parse_args()
@@ -513,7 +526,7 @@ def main():
 
     dl = DataLoader(args.target, args.database, host=args.host, port=args.port,
                     startdate=args.start, enddate=args.end)
-    dl.run()
+    dl.run(args.skip_file_check)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a small bug and add the ability to skip the file check against the database.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The bug caused crashes when the error the bug was in was raised. Also, since the files weren't changing during the hk v2 update having the script check the database for file changes/new files was just a needless, and sometimes slow, process. The flag allows us to just skip it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was implemented and used during the UCSD hk v2 update.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
