### PR TITLE
Allow str type in Feed

### DIFF
--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -239,7 +239,7 @@ class Feed:
                 'data' dictionary value published (see Feed.publish_message for details).
 
         """
-        valid_types = (float, int)
+        valid_types = (float, int, str)
 
         # multi-sample check
         if isinstance(value, list):

--- a/tests/test_ocs_feed.py
+++ b/tests/test_ocs_feed.py
@@ -47,8 +47,7 @@ class TestPublishMessage:
         test_feed.publish_message(test_message)
 
     def test_str_single_sample_input(self):
-        """Passing a string, even just one, should cause an error upon
-        publishing.
+        """We should also now be able to pass strings.
 
         """
         mock_agent = MagicMock()
@@ -63,11 +62,10 @@ class TestPublishMessage:
             }
         }
 
-        with pytest.raises(TypeError):
-            test_feed.publish_message(test_message)
+        test_feed.publish_message(test_message)
 
     def test_str_multi_sample_input(self):
-        """Passing multiple points, including multiple invalid datatypes,
+        """Passing multiple points, including invalid datatypes,
         should cause a TypeError upon publishing.
 
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The switch to using the G3Timesample object to store data instead of IrregBlockDouble in #128 allows us to store strings in a G3String. The OCS Feeds check the type of data being passed to them and previously strings were restricted. This allows them to be published on Feeds.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The M1000 Agent being developed in socs will pass string descriptions of the state of the hardware along with integers which encode those strings. Without this patch the strings cause an error to be raised when publishing to the Feed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tests updated to try passing a string to the feed (and pass locally.) I've also been developing the M1000 Agent and passing strings from it based on a patched OCS with this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
