### PR TITLE
docs: use autodoc_mock_imports for spt3g, so3g

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,4 +17,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@OCS_DOC_BUILD=True $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,8 @@ pygments_style = 'sphinx'
 # Have __init__ and class docstrings both show up
 autoclass_content = "both"
 
+autodoc_mock_imports = ['spt3g', 'so3g']
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -9,13 +9,8 @@ import txaio
 
 from ocs import ocs_feed
 
-if os.getenv('OCS_DOC_BUILD') != 'True':
-    from spt3g import core
-    import so3g
-    G3Module = core.G3Module
-else:
-    # Alias classes that are needed for clean import in docs build.
-    G3Module = object
+from spt3g import core
+import so3g
 
 
 HKAGG_VERSION = 2
@@ -456,7 +451,7 @@ class Provider:
         return frame
 
 
-class G3FileRotator(G3Module):
+class G3FileRotator(core.G3Module):
     """
     G3 module which handles file rotation.
     After time_per_file has elapsed, the rotator will end that file and create


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This allows autodoc to run on readthedocs... without the OCS_DOC_BUILD business I put in before.  The aggregator API stuff has not been rendering since HK v2 went in.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Recent builds on readthedocs have been failing to process the aggregator.py source file, because some spt3g core.G3* classes were being accessed on import.  sphinx has a feature to dodge this.  For example, [the API section](https://ocs.readthedocs.io/en/latest/agents/aggregator.html#api) is totally empty.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested that the docs build locally even if so3g or spt3g aren't available.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
