### PR TITLE
site_config: use a string comparison instead of identification

### DIFF
--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -286,7 +286,7 @@ class ArgContainer:
         """
         arg_list = []
         for k, v in self.arg_dict.items():
-            if k is not '__positional__':
+            if k != '__positional__':
                 arg_list.append(k)
             arg_list.extend(v)
 


### PR DESCRIPTION
setup.py is catching this bad usage.

It's a trivial fix, speaks for itself...

