### PR TITLE
Expand session.data documentation

### DIFF
--- a/agents/fake_data/fake_data_agent.py
+++ b/agents/fake_data/fake_data_agent.py
@@ -132,7 +132,7 @@ class FakeDataAgent:
             for channel, samples in block.data.items():
                 data_cache['fields'][channel] = samples[-1]
             data_cache['timestamp'] = block.timestamps[-1]
-            session.data = data_cache
+            session.data.update(data_cache)
 
         self.agent.feeds['false_temperatures'].flush_buffer()
         self.set_job_done()

--- a/agents/fake_data/fake_data_agent.py
+++ b/agents/fake_data/fake_data_agent.py
@@ -56,6 +56,10 @@ class FakeDataAgent:
                  "channel_03": 0.10793263271024509},
              "timestamp":1600448753.9288929}
 
+        The channels kept in fields are the 'faked' data, in a similar
+        structure to the Lakeshore agents. 'timestamp' is the lastest time these values
+        were updated.
+
         """
         ok, msg = self.try_set_job('acq')
         if not ok: return ok, msg

--- a/agents/fake_data/fake_data_agent.py
+++ b/agents/fake_data/fake_data_agent.py
@@ -53,20 +53,8 @@ class FakeDataAgent:
                 {"channel_00": 0.10250430068515494,
                  "channel_01": 0.08550903376216404,
                  "channel_02": 0.10481891991693446,
-                 "channel_03": 0.1060597011760155,
-                 "channel_04": 0.1019265554541543,
-                 "channel_05": 0.09389479275963578,
-                 "channel_06": 0.10071855402986646,
-                 "channel_07": 0.09601271802732826,
-                 "channel_08": 0.09760831143883832,
-                 "channel_09": 0.11345360178932645,
-                 "channel_10": 0.10047676575328081,
-                 "channel_11": 0.09534462609141414,
-                 "channel_12": 0.09654199950059912,
-                 "channel_13": 0.11051763608358373,
-                 "channel_14": 0.1062686192067794,
-                 "channel_15": 0.10793263271024509},
-             "last_updated":1600448753.9288929}
+                 "channel_03": 0.10793263271024509},
+             "timestamp":1600448753.9288929}
 
         """
         ok, msg = self.try_set_job('acq')
@@ -136,10 +124,10 @@ class FakeDataAgent:
             session.app.publish_to_feed('false_temperatures', block.encoded())
 
             # Update session.data
-            data_cache = {"fields": {}, "last_updated": None}
+            data_cache = {"fields": {}, "timestamp": None}
             for channel, samples in block.data.items():
                 data_cache['fields'][channel] = samples[-1]
-            data_cache['last_updated'] = block.timestamps[-1]
+            data_cache['timestamp'] = block.timestamps[-1]
             session.data = data_cache
 
         self.agent.feeds['false_temperatures'].flush_buffer()

--- a/agents/fake_data/fake_data_agent.py
+++ b/agents/fake_data/fake_data_agent.py
@@ -46,6 +46,28 @@ class FakeDataAgent:
 
         This Process has no useful parameters.
 
+        The most recent fake values are stored in the session.data object in
+        the format::
+
+            {"fields":
+                {"channel_00": 0.10250430068515494,
+                 "channel_01": 0.08550903376216404,
+                 "channel_02": 0.10481891991693446,
+                 "channel_03": 0.1060597011760155,
+                 "channel_04": 0.1019265554541543,
+                 "channel_05": 0.09389479275963578,
+                 "channel_06": 0.10071855402986646,
+                 "channel_07": 0.09601271802732826,
+                 "channel_08": 0.09760831143883832,
+                 "channel_09": 0.11345360178932645,
+                 "channel_10": 0.10047676575328081,
+                 "channel_11": 0.09534462609141414,
+                 "channel_12": 0.09654199950059912,
+                 "channel_13": 0.11051763608358373,
+                 "channel_14": 0.1062686192067794,
+                 "channel_15": 0.10793263271024509},
+             "last_updated":1600448753.9288929}
+
         """
         ok, msg = self.try_set_job('acq')
         if not ok: return ok, msg
@@ -112,6 +134,13 @@ class FakeDataAgent:
 
             # self.log.info('Sending %i data on %i channels.' % (len(t), len(T)))
             session.app.publish_to_feed('false_temperatures', block.encoded())
+
+            # Update session.data
+            data_cache = {"fields": {}, "last_updated": None}
+            for channel, samples in block.data.items():
+                data_cache['fields'][channel] = samples[-1]
+            data_cache['last_updated'] = block.timestamps[-1]
+            session.data = data_cache
 
         self.agent.feeds['false_temperatures'].flush_buffer()
         self.set_job_done()

--- a/docs/agents/fake_data.rst
+++ b/docs/agents/fake_data.rst
@@ -14,6 +14,35 @@ Command-line / site config args
    :func: add_agent_args
    :prog: fake_data_agent.py
 
+Configuration File Examples
+---------------------------
+Below are configuration examples for the ocs config file and for running the Agent in a docker container.
+
+ocs-config
+``````````
+To configure the Fake Data Agent we need to add a FakeDAtaAgent block to our
+ocs configuration file. Here is an example configuration block using all of the
+available arguments::
+
+    {'agent-class': 'FakeDataAgent',
+     'instance-id': 'fake-data1',
+     'arguments': [['--mode', 'acq'],
+                   ['--num-channels', '16'],
+                   ['--sample-rate', '4']]},
+
+Docker
+``````
+The Fake Data Agent can also be run in a Docker container. An example
+docker-compose service configuration is shown here::
+
+    fake-data1:
+        image: simonsobs/ocs-fake-data-agent
+        hostname: ocs-docker
+        volumes:
+          - ${OCS_CONFIG_DIR}:/config:ro
+        command:
+          - "--instance-id=fake-data1"
+
 Agent Operations
 ----------------
 

--- a/docs/agents/fake_data.rst
+++ b/docs/agents/fake_data.rst
@@ -20,7 +20,7 @@ Below are configuration examples for the ocs config file and for running the Age
 
 ocs-config
 ``````````
-To configure the Fake Data Agent we need to add a FakeDAtaAgent block to our
+To configure the Fake Data Agent we need to add a FakeDataAgent block to our
 ocs configuration file. Here is an example configuration block using all of the
 available arguments::
 

--- a/docs/developer/clients.rst
+++ b/docs/developer/clients.rst
@@ -185,6 +185,7 @@ Client example would be::
 
     therm_client.acq.start()
 
+.. _op_replies:
 
 Replies from Operation methods
 ------------------------------

--- a/docs/developer/data.rst
+++ b/docs/developer/data.rst
@@ -1,0 +1,10 @@
+Data Access
+===========
+
+OCS is designed for distributed data acquisition. This section describes ways
+data is collected and passed across the OCS network, and how data can be
+queried by OCS Clients.
+
+.. toctree::
+    feeds
+    session-data

--- a/docs/developer/session-data.rst
+++ b/docs/developer/session-data.rst
@@ -1,0 +1,177 @@
+session.data
+============
+
+Data Feeds make use of the crossbar Pub/Sub functionality to pass data around
+the network, however, sometimes you might not want to receive all data, just
+the most recent values. For this purpose there is the OpSession data attribute.
+This is per OCS operation location to store recent data of interest to OCS
+Agent users.
+
+Often this is used to store the most recent values that are queried by the
+Agent, for example the temperature of thermometers on a Lakeshore device. This
+information can then be retrieved by a running OCS client and used to inform
+operation of the Client, for instance waiting until a certain temperature set
+point in your cryostat before starting detector data acquisition.
+
+Agent Access
+------------
+
+To understand how to add data to the ``session.data`` object let's look at the
+Fake Data Agent as an example, specifically at its primary Process,
+``start_acq``:
+
+.. code-block:: python
+   :linenos:
+
+    def start_acq(self, session, params=None):
+        """**Process:**  Acquire data and write to the feed.
+
+        This Process has no useful parameters.
+
+        The most recent fake values are stored in the session.data object in
+        the format::
+
+            {"fields":
+                {"channel_00": 0.10250430068515494,
+                 "channel_01": 0.08550903376216404,
+                 "channel_02": 0.10481891991693446,
+                 "channel_03": 0.1060597011760155,
+                 "channel_04": 0.1019265554541543,
+                 "channel_05": 0.09389479275963578,
+                 "channel_06": 0.10071855402986646,
+                 "channel_07": 0.09601271802732826,
+                 "channel_08": 0.09760831143883832,
+                 "channel_09": 0.11345360178932645,
+                 "channel_10": 0.10047676575328081,
+                 "channel_11": 0.09534462609141414,
+                 "channel_12": 0.09654199950059912,
+                 "channel_13": 0.11051763608358373,
+                 "channel_14": 0.1062686192067794,
+                 "channel_15": 0.10793263271024509},
+             "last_updated":1600448753.9288929}
+
+        """
+        ok, msg = self.try_set_job('acq')
+        if not ok: return ok, msg 
+        session.set_status('running')
+
+        if params is None:
+            params = {}
+
+        T = [.100 for c in self.channel_names]
+        block = ocs_feed.Block('temps', self.channel_names)
+
+        next_timestamp = time.time()
+        reporting_interval = 1.
+        next_report = next_timestamp + reporting_interval
+
+        self.log.info("Starting acquisition")
+
+        while True:
+            with self.lock:
+                if self.job == '!acq':
+                    break
+                elif self.job == 'acq':
+                    pass
+                else:
+                    return 10
+
+            now = time.time()
+            delay_time = next_report - now 
+            if delay_time > 0:
+                time.sleep(min(delay_time, 1.))
+                continue
+
+            # Safety: if we ever get waaaay behind, reset.
+            if delay_time / reporting_interval < -3: 
+                self.log.info('Got way behind in reporting: %.1s seconds. '
+                              'Dropping fake data.' % delay_time)
+                next_timestamp = now 
+                next_report = next_timestamp + reporting_interval
+                continue
+
+            # Pretend we got it exactly.
+            n_data = int((next_report - next_timestamp) * self.sample_rate)
+
+            # Set the next report time, before checking n_data.
+            next_report += reporting_interval
+
+            # This is to handle the (acceptable) case of sample_rate < 0.
+            if (n_data <= 0): 
+                time.sleep(.1)
+                continue
+
+            # New data bundle.
+            t = next_timestamp + np.arange(n_data) / self.sample_rate
+            block.timestamps = list(t)
+
+            # Unnecessary realism: 1/f.
+            T = [_t + np.random.uniform(-1, 1) * .003 for _t in T]
+            for _t, _c in zip(T, self.channel_names):
+                block.data[_c] = list(_t + np.random.uniform(
+                    -1, 1, size=len(t)) * .002)
+
+            # This will keep good fractional time.
+            next_timestamp += n_data / self.sample_rate
+
+            # self.log.info('Sending %i data on %i channels.' % (len(t), len(T)))
+            session.app.publish_to_feed('false_temperatures', block.encoded())
+
+            # Update session.data
+            data_cache = {"fields": {}, "last_updated": None}
+            for channel, samples in block.data.items():
+                data_cache['fields'][channel] = samples[-1]
+            data_cache['last_updated'] = block.timestamps[-1]
+            session.data = data_cache
+
+        self.agent.feeds['false_temperatures'].flush_buffer()
+        self.set_job_done()
+        return True, 'Acquisition exited cleanly.'
+
+There's a lot going on here, which mostly has to do with generating the random
+data that the Agent produces for testing. The part relevant for our discussion
+is lines 95-100::
+
+    # Update session.data
+    data_cache = {"fields": {}, "last_updated": None}
+    for channel, samples in block.data.items():
+        data_cache['fields'][channel] = samples[-1]
+    data_cache['last_updated'] = block.timestamps[-1]
+    session.data = data_cache
+
+This block formats the latest values for each "channel" into a dictionary and
+stores it in ``session.data``. The format of the data stored in
+``session.data`` is left to the Agent developer, and should be documented in
+the docstring for the Process.
+
+.. note::
+    You should consider the desired structure carefully, as future changes the
+    data structure may cause existing clients that make use of the ``session.data``
+    object to break. Changes that do take place should be announced in the
+    change logs of new OCS versions.
+
+Client Access
+-------------
+Once your Agent is storing information in the ``session.data`` object you
+likely want to access it via an OCS client. The ``session`` object is returned
+by all :ref:`Operation Methods<op_replies>`, for instance the ``status`` method, as shown in this small example::
+
+    from ocs.matched_client import MatchedClient
+    
+    therm_client = MatchedClient('fake-data1')
+    therm_client.acq.start()
+    
+    response = therm_client.acq.status()
+    
+After running the client we can examine the data dict stored within the response::
+
+    >>> print(response.session.get('data'))
+    {'fields': {'channel_00': 0.11220355191080153, 'channel_01':
+    0.0850365880364649, 'channel_02': 0.16598799420080332, 'channel_03':
+    0.26583693634591293, 'channel_04': 0.24601374140729332, 'channel_05':
+    0.17319844739787155, 'channel_06': 0.1289138204655707, 'channel_07':
+    0.21682049008200877, 'channel_08': 0.15539914447393058, 'channel_09':
+    0.18161931031171688, 'channel_10': 0.040315857256297216, 'channel_11':
+    0.06916760928468035, 'channel_12': 0.11291917165165984, 'channel_13':
+    0.0996764253503196, 'channel_14': 0.019171783828962213, 'channel_15':
+    0.06879881165286862}, 'last_updated': 1600717477.2989068}

--- a/docs/developer/session-data.rst
+++ b/docs/developer/session-data.rst
@@ -137,12 +137,14 @@ is lines 95-100::
     for channel, samples in block.data.items():
         data_cache['fields'][channel] = samples[-1]
     data_cache['last_updated'] = block.timestamps[-1]
-    session.data = data_cache
+    session.data.update(data_cache)
+
 
 This block formats the latest values for each "channel" into a dictionary and
 stores it in ``session.data``. The format of the data stored in
 ``session.data`` is left to the Agent developer, and should be documented in
-the docstring for the Process.
+the docstring for the Process. This documentation should include a description
+of what you are including and what that information means.
 
 .. note::
     You should consider the desired structure carefully, as future changes the

--- a/docs/developer/session-data.rst
+++ b/docs/developer/session-data.rst
@@ -122,7 +122,7 @@ Fake Data Agent as an example, specifically at its primary Process,
             for channel, samples in block.data.items():
                 data_cache['fields'][channel] = samples[-1]
             data_cache['last_updated'] = block.timestamps[-1]
-            session.data = data_cache
+            session.data.update(data_cache)
 
         self.agent.feeds['false_temperatures'].flush_buffer()
         self.set_job_done()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,9 +44,9 @@ write OCS Agents or Clients.
 
     developer/architecture
     developer/site_config
-    developer/feeds
     developer/agents
     developer/clients
+    developer/data
     developer/web
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is an attempt to expand on the documentation for `session.data`, describing how one should add information to their Agent Process `session.data` object and how to interact with that object in an OCS Client. To do so I've added the use of `session.data` to the Fake Data Agent.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using `session.data` is very helpful, but it's currently an underused feature across the existing Agents. Hoping an example in the Fake Data Agent will provide a good reference for Agent authors and encourage more use of this feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've run the modified Fake Data Agent in a small test environment and run the example code shown.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
