### PR TITLE
Install and add dumb-init to Agent Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN apt-get update && apt-get install -y python3 \
     python3-pip \
     vim
 
+# Install init system
+RUN pip3 install dumb-init
+
 # Copy the current directory contents into the container at /app
 COPY . /app/ocs/
 

--- a/agents/aggregator/Dockerfile
+++ b/agents/aggregator/Dockerfile
@@ -13,10 +13,8 @@ COPY aggregator_agent.py .
 RUN mkdir -p /data && \
     chown ocs:ocs /data
 
-
-
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "aggregator_agent.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "aggregator_agent.py"]
 
 # Sensible defaults for setup with sisock
 CMD ["--site-hub=ws://crossbar:8001/ws", \

--- a/agents/fake_data/Dockerfile
+++ b/agents/fake_data/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app/ocs/agents/fake_data/
 COPY . .
 
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "fake_data_agent.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "fake_data_agent.py"]
 
 # Sensible defaults for setup with sisock
 CMD ["--site-hub=ws://crossbar:8001/ws", \

--- a/agents/influxdb_publisher/Dockerfile
+++ b/agents/influxdb_publisher/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app/ocs/agents/influxdb_publisher/
 COPY influxdb_publisher.py .
 
 # Run publisher on container startup
-ENTRYPOINT ["python3", "-u", "influxdb_publisher.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "influxdb_publisher.py"]
 
 # Sensible defaults for setup with sisock
 CMD ["--site-hub=ws://crossbar:8001/ws", \

--- a/agents/registry/Dockerfile
+++ b/agents/registry/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app/ocs/agents/registry/
 COPY . .
 
 # Run registry on container startup
-ENTRYPOINT ["python3", "-u", "registry.py"]
+ENTRYPOINT ["dumb-init", "python3", "-u", "registry.py"]
 
 # Sensible defaults for setup with sisock
 CMD ["--site-hub=ws://crossbar:8001/ws", \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As described in #168, having the Agents be PID 1 within the container can lead to improper handling of signals. There are a couple of lightweight init systems designed for use within Docker containers, we use `dumb-init` and add it to all agent containers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #168

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've run the aggregator, fake data agent, and influxdb publisher Agents in a test environment and things are working as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
