### PR TITLE
Remove empty blocks' block_name from frame

### DIFF
--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -445,7 +445,10 @@ class Provider:
             frame['blocks'].append(m)
             block_names.append(block_name)
 
-        frame['block_names'] = core.G3VectorString(block_names)
+        if 'block_names' in frame:
+            frame['block_names'].extend(block_names)
+        else:
+            frame['block_names'] = core.G3VectorString(block_names)
 
         if clear:
             self.clear()

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -428,16 +428,10 @@ class Provider:
 
         frame['address'] = self.address
         frame['provider_session_id'] = self.sessid
-        if 'block_names' in frame:
-            frame['block_names'].extend(list(self.blocks.keys()))
-        else:
-            frame['block_names'] = core.G3VectorString(list(self.blocks.keys()))
 
+        block_names = []
         for block_name, block in self.blocks.items():
             if not block.timestamps:
-                # Remove empty block's block_name
-                bnidx = list(frame['block_names']).index(block_name)
-                frame['block_names'].__delitem__(bnidx)
                 continue
             try:
                 m = core.G3TimesampleMap()
@@ -449,6 +443,10 @@ class Provider:
                               e=e)
                 continue
             frame['blocks'].append(m)
+            block_names.append(block_name)
+
+        frame['block_names'] = core.G3VectorString(block_names)
+
         if clear:
             self.clear()
         return frame

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -435,6 +435,9 @@ class Provider:
 
         for block_name, block in self.blocks.items():
             if not block.timestamps:
+                # Remove empty block's block_name
+                bnidx = list(frame['block_names']).index(block_name)
+                frame['block_names'].__delitem__(bnidx)
                 continue
             try:
                 m = core.G3TimesampleMap()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If a block has no timestamps, don't include the "block_name" in the frame. Add a test to verify this behavior.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If a previously published block wasn't published during a frame, the block's
name would end up in the frame's "block_names" list anyway. We now don't include it if
the block is empty, i.e. if there are no timestamps.

This was found when UCSD started using the M1000 Agent. It contains a very sparsely sampled field and associated block. They were unable to open saved files, which led to finding invalid frames being saved with `len(block_names) != len(blocks)`. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
New test, `test_sparsely_sampled_block`, added to `test_aggregator.py`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
