### PR TITLE
Ignore and log invalid kwargs passed to Providers

### DIFF
--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -168,7 +168,9 @@ class Provider:
         self.last_refresh = time.time() # Determines if
         self.last_block_received = None
 
-        self.log.warn("Recieved unxpected keyword argument(s): {kwarg}", kwarg=kwargs)
+        self.log.warn("Recieved unxpected keyword argument(s), {kwarg}, when " +
+                      "registering the feed with address '{add}'",
+                      kwarg=kwargs, add=self.address)
 
     def encoded(self):
         return {

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -6,6 +6,7 @@ import re
 from typing import Dict
 
 import txaio
+txaio.use_twisted()
 
 from ocs import ocs_feed
 
@@ -151,7 +152,7 @@ class Provider:
             txaio logger
 
     """
-    def __init__(self, address, sessid, prov_id, frame_length=5*60, fresh_time=3*60):
+    def __init__(self, address, sessid, prov_id, frame_length=5*60, fresh_time=3*60, **kwargs):
         self.address = address
         self.sessid = sessid
         self.frame_length = frame_length
@@ -166,6 +167,8 @@ class Provider:
         self.fresh_time = fresh_time
         self.last_refresh = time.time() # Determines if
         self.last_block_received = None
+
+        self.log.warn("Recieved unxpected keyword argument(s): {kwarg}", kwarg=kwargs)
 
     def encoded(self):
         return {

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -363,3 +363,10 @@ def test_g3_cast():
     for x in incorrect_tests:
         with pytest.raises(TypeError) as e_info:
             g3_cast(x)
+
+# Tests related to #148
+def test_arbitrary_args_to_provider():
+    """Unexpected kwargs should be ignored."""
+    malformed_agg_params = {'not a valid key': 60,
+                            'frame length': 120}
+    provider = Provider('test_provider', 'test_sessid', 3, 1, **malformed_agg_params)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a ``**kwargs`` parameter to the `Providers` class, allowing us to ignore invalid kwargs passed via the `agg_params` dict defined in Agents and passed to `OCSAgent.register_feeds()`.

Note that this doesn't provide the Agent writer any real feedback on the fact they've included invalid kwargs, but does log it to the Aggregator Agent logs as a warning.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #148

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
A unit test has been added that creates a provider with invalid kwargs. This would fail without the new ``**kwargs`` parameter.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
