### PR TITLE
Added feed exclusion options

### DIFF
--- a/agents/influxdb_publisher/influxdb_publisher.py
+++ b/agents/influxdb_publisher/influxdb_publisher.py
@@ -90,6 +90,8 @@ class Publisher:
         """
         while not self.incoming_data.empty():
             data, feed = self.incoming_data.get()
+            if feed['agg_params'].get('exclude_influx', False):
+                return
 
             LOG.debug("Pulling data from queue.")
 

--- a/agents/influxdb_publisher/influxdb_publisher.py
+++ b/agents/influxdb_publisher/influxdb_publisher.py
@@ -91,7 +91,7 @@ class Publisher:
         while not self.incoming_data.empty():
             data, feed = self.incoming_data.get()
             if feed['agg_params'].get('exclude_influx', False):
-                return
+                continue
 
             LOG.debug("Pulling data from queue.")
 

--- a/docs/developer/feeds.rst
+++ b/docs/developer/feeds.rst
@@ -60,12 +60,19 @@ The following options can be specified here:
 .. list-table:: Aggregator params
     :widths: 20 20
 
-    * - frame_length
+    * - frame_length (float)
       - Aggregation time (seconds) before frame is written to disk
 
-    * - fresh_time
+    * - fresh_time (float)
       - Time (seconds) before feed is considered "stale", and is removed from
         the HK status frame
+
+    * - exclude_aggregator (bool)
+      - If True, the HK Aggregator will not record this feed to G3.
+
+    * - exclude_influx (bool)
+      - If True, the InfluxPublisher will not publish feed to the influx
+        database.
 
 
 Publishing to a Feed

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -617,6 +617,9 @@ class Aggregator:
 
             data, feed = self.incoming_data.get()
 
+            if feed['agg_params'].get('exclude_aggregator', False):
+                return
+
             address = feed['address']
             sessid = feed['session_id']
 

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -618,7 +618,7 @@ class Aggregator:
             data, feed = self.incoming_data.get()
 
             if feed['agg_params'].get('exclude_aggregator', False):
-                return
+                continue
 
             address = feed['address']
             sessid = feed['session_id']

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -413,20 +413,9 @@ class OCSAgent(ApplicationSession):
                 Determines if feed should be aggregated. At the moment, each agent
                 can have at most one aggregated feed. Defaults to False
             agg_params (dict, optional):
-                Parameters used by the aggregator.
-
-                Params:
-                    **frame_length** (float):
-                        Deterimes the amount of time each G3Frame should be (in seconds).
-                    **fresh_time** (float):
-                        Time (seconds) before feed is considered "stale" and
-                        removed from the HK status frame
-                    **exclude_aggregator** (bool):
-                        If True, the HK Aggregator will not record feed to g3.
-                    **exclude_influx** (bool):
-                        If True, the InfluxPublisher will not write the feed to
-                        Influx.
-
+                Parameters used by the aggregator and influx publisher.  See
+                the ``ocs.ocs_feed.Feed`` docstring for the full list of
+                aggregator params.
             buffer_time (int, optional):
                 Specifies time that messages should be buffered in seconds.
                 If 0, message will be published immediately.

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -421,6 +421,11 @@ class OCSAgent(ApplicationSession):
                     **fresh_time** (float):
                         Time (seconds) before feed is considered "stale" and
                         removed from the HK status frame
+                    **exclude_aggregator** (bool):
+                        If True, the HK Aggregator will not record feed to g3.
+                    **exclude_influx** (bool):
+                        If True, the InfluxPublisher will not write the feed to
+                        Influx.
 
             buffer_time (int, optional):
                 Specifies time that messages should be buffered in seconds.

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -72,13 +72,18 @@ class Feed:
             Determines if feed should be aggregated. At the moment, each agent
             can have at most one aggregated feed. Defaults to False
         agg_params (dict, optional):
-            Parameters used by the aggregator.
+            Parameters used by the aggregator and influx publisher.
 
             Params:
                 **frame_length** (float):
                     Deterimes the amount of time each G3Frame should be (in seconds).
-                **fresh_time** (float)
+                **fresh_time** (float):
                     Time until feed is considered stale by aggregator.
+                **exclude_aggregator** (bool):
+                    If True, the HK Aggregator will not record feed to g3.
+                **exclude_influx** (bool):
+                    If True, the InfluxPublisher will not write the feed to
+                    Influx.
 
         buffer_time (int, optional):
             Specifies time that messages should be buffered in seconds.

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -363,10 +363,3 @@ def test_g3_cast():
     for x in incorrect_tests:
         with pytest.raises(TypeError) as e_info:
             g3_cast(x)
-
-# Tests related to #148
-def test_arbitrary_args_to_provider():
-    """Unexpected kwargs should be ignored."""
-    malformed_agg_params = {'not a valid key': 60,
-                            'frame length': 120}
-    provider = Provider('test_provider', 'test_sessid', 3, 1, **malformed_agg_params)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds the `exclude_aggregator` and `exclude_influx` aggregation parameters, which will keep data from being published to g3 and influx respectively.

## Description
<!--- Describe your changes in detail -->
Added a check in the aggregator / influx feed callbacks that check for the `exclude_aggregator` or `exclude_influx` option, and will toss the data if set to `True`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows for "influx only" or "aggregator only" feeds. Right now it's needed to allows feeds with higher data rates to bypass the influx publisher while still being recorded in 3g.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally with the `fake_data` agent. Checked to see that no data is published to influx when the parameter is set.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
