### PR TITLE
InfluxDB ServerError handling, line protocol, and gzip support

### DIFF
--- a/agents/influxdb_publisher/influxdb_publisher.py
+++ b/agents/influxdb_publisher/influxdb_publisher.py
@@ -4,6 +4,7 @@ import queue
 import argparse
 import txaio
 
+from functools import wraps
 from os import environ
 from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
@@ -15,17 +16,33 @@ from ocs import ocs_agent, site_config
 txaio.use_twisted()
 LOG = txaio.make_logger()
 
+def timing(f):
+    @wraps(f)
+    def wrap(*args, **kw):
+        ts = time.time()
+        result = f(*args, **kw)
+        te = time.time()
+        #print(f'func:{f.__name__} args:[{args}, {kw}] took: {te-ts:.4f} sec')
+        print(f'func:{f.__name__} took: {te-ts:.4f} sec')
+        return result
+    return wrap
 
-def timestamp2influxtime(time):
+def timestamp2influxtime(time, protocol):
     """Convert timestamp for influx
 
     Args:
         time:
             ctime timestamp
+        protocol:
+            'json' or line'
 
     """
-    t_dt = datetime.datetime.fromtimestamp(time)
-    return t_dt.strftime("%Y-%m-%dT%H:%M:%S.%f")
+    if protocol == 'json':
+        t_dt = datetime.datetime.fromtimestamp(time)
+        influx_t = t_dt.strftime("%Y-%m-%dT%H:%M:%S.%f")
+    elif protocol == 'line':
+        influx_t = int(time*1e9)  # ns
+    return influx_t
 
 
 class Publisher:
@@ -44,6 +61,10 @@ class Publisher:
             database name within InfluxDB to publish to
         port (int, optional):
             port for InfluxDB instance, defaults to 8086.
+        protocol (str, optional):
+            Protocol for writing data. Either 'line' or 'json'.
+        gzip (bool, optional):
+            compress influxdb requsts with gzip
 
     Attributes:
         host (str):
@@ -58,13 +79,18 @@ class Publisher:
             InfluxDB client connection
 
     """
-    def __init__(self, host, database, incoming_data, port=8086):
+    def __init__(self, host, database, incoming_data, port=8086, protocol='line', gzip=False):
         self.host = host
         self.port = port
         self.db = database
         self.incoming_data = incoming_data
+        self.protocol = protocol
+        self.gzip = gzip
 
-        self.client = InfluxDBClient(host=self.host, port=self.port)
+        print(f"gzip encoding enabled: {gzip}")
+        print(f"data protocol: {protocol}")
+
+        self.client = InfluxDBClient(host=self.host, port=self.port, gzip=gzip)
 
         db_list = None
         # ConnectionError here is indicative of InfluxDB being down
@@ -73,7 +99,7 @@ class Publisher:
                 db_list = self.client.get_list_database()
             except RequestsConnectionError:
                 LOG.error("Connection error, attempting to reconnect to DB.")
-                self.client = InfluxDBClient(host=self.host, port=self.port)
+                self.client = InfluxDBClient(host=self.host, port=self.port, gzip=gzip)
                 time.sleep(1)
         db_names = [x['name'] for x in db_list]
 
@@ -83,6 +109,7 @@ class Publisher:
 
         self.client.switch_database(self.db)
 
+    @timing
     def process_incoming_data(self):
         """
         Takes all data from the incoming_data queue, and puts them into
@@ -96,20 +123,24 @@ class Publisher:
             LOG.debug("Pulling data from queue.")
 
             # Formatted for writing to InfluxDB
-            payload = self.format_data(data, feed)
+            payload = self.format_data(data, feed, protocol=self.protocol)
             try:
-                self.client.write_points(payload)
+                self.client.write_points(payload,
+                                         batch_size=10000,
+                                         protocol=self.protocol,
+                                         )
                 LOG.debug("wrote payload to influx")
             except RequestsConnectionError:
                 LOG.error("InfluxDB unavailable, attempting to reconnect.")
-                self.client = InfluxDBClient(host=self.host, port=self.port)
+                self.client = InfluxDBClient(host=self.host, port=self.port, gzip=self.gzip)
                 self.client.switch_database(self.db)
             except InfluxDBClientError as err:
                 LOG.error("InfluxDB Client Error: {e}", e=err)
             except InfluxDBServerError as err:
                 LOG.error("InfluxDB Server Error: {e}", e=err)
 
-    def format_data(self, data, feed):
+    @timing
+    def format_data(self, data, feed, protocol):
         """Format the data from an OCS feed into a dict for pushing to InfluxDB.
 
         The scheme here is as follows:
@@ -126,6 +157,8 @@ class Publisher:
             feed (dict):
                 feed from the OCS Feed subscription, contains feed information
                 used to structure our influxdb query
+            protocol (str):
+                Protocol for writing data. Either 'line' or 'json'.
 
         """
         measurement = feed['agent_address']
@@ -145,16 +178,33 @@ class Publisher:
                 grouped_data_points.append(grouped_dict)
 
             for fields, time_ in zip(grouped_data_points, times):
-                json_body.append(
-                    {
-                        "measurement": measurement,
-                        "time": timestamp2influxtime(time_),
-                        "fields": fields,
-                        "tags": {
-                            "feed": feed_tag
+                if protocol == 'line':
+                    fields_line = []
+                    for mk, mv in fields.items():
+                        f_line = f"{mk}={mv}"
+                        if isinstance(mv, int):
+                            f_line += "i"
+                        fields_line.append(f_line)
+
+                    measurement_line = ','.join(fields_line)
+                    t_line = timestamp2influxtime(time_, protocol='line')
+                    line = f"{measurement},feed={feed_tag} {measurement_line} {t_line}"
+                    # print(line)
+
+                    json_body.append(line)
+                elif protocol == 'json':
+                    json_body.append(
+                        {
+                            "measurement": measurement,
+                            "time": timestamp2influxtime(time_, protocol='json'),
+                            "fields": fields,
+                            "tags": {
+                                "feed": feed_tag
+                            }
                         }
-                    }
-                )
+                    )
+                else:
+                    self.log.warn(f"Protocol '{protocol}' not supported.")
 
         LOG.debug("payload: {p}", p=json_body)
 
@@ -239,13 +289,19 @@ class InfluxDBAgent:
         session.set_status('starting')
         self.aggregate = True
 
-        LOG.debug("Instatiating Publisher class")
-        publisher = Publisher(self.args.host, self.args.database,
-                              self.incoming_data, port=self.args.port)
+        self.log.debug("Instatiating Publisher class")
+        publisher = Publisher(self.args.host,
+                              self.args.database,
+                              self.incoming_data,
+                              port=self.args.port,
+                              protocol=self.args.protocol,
+                              gzip=self.args.gzip,
+                              )
 
         session.set_status('running')
         while self.aggregate:
             time.sleep(self.loop_time)
+            self.log.info(f"Approx. queue size: {self.incoming_data.qsize()}")
             publisher.run()
 
         publisher.close()
@@ -276,6 +332,14 @@ def make_parser(parser=None):
     pgroup.add_argument('--database',
                         default='ocs_feeds',
                         help="Database within InfluxDB to publish data to.")
+    pgroup.add_argument('--protocol',
+                        default='line',
+                        choices=['json', 'line'],
+                        help="Protocol for writing data. Either 'line' or 'json'.")
+    pgroup.add_argument('--gzip',
+                        type=bool,
+                        default=False,
+                        help="Use gzip content encoding to compress requests.")
 
     return parser
 

--- a/agents/influxdb_publisher/influxdb_publisher.py
+++ b/agents/influxdb_publisher/influxdb_publisher.py
@@ -6,7 +6,7 @@ import txaio
 
 from os import environ
 from influxdb import InfluxDBClient
-from influxdb.exceptions import InfluxDBClientError
+from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from ocs import ocs_agent, site_config
@@ -106,6 +106,8 @@ class Publisher:
                 self.client.switch_database(self.db)
             except InfluxDBClientError as err:
                 LOG.error("InfluxDB Client Error: {e}", e=err)
+            except InfluxDBServerError as err:
+                LOG.error("InfluxDB Server Error: {e}", e=err)
 
     def format_data(self, data, feed):
         """Format the data from an OCS feed into a dict for pushing to InfluxDB.

--- a/docs/agents/influxdb_publisher.rst
+++ b/docs/agents/influxdb_publisher.rst
@@ -19,6 +19,8 @@ Add an InfluxDBAgent to your OCS configuration file::
        'arguments': [['--initial-state', 'record'],
                      ['--host', 'influxdb'],
                      ['--port', 8086],
+                     ['--protocol', 'line'],
+                     ['--gzip', True],
                      ['--database', 'ocs_feeds']]},
 
 docker-compose Configuration
@@ -96,3 +98,11 @@ the SELECT query.
 For more information about using InfluxDB in Grafana, see the `Grafana Documentation`_.
 
 .. _`Grafana Documentation`: https://grafana.com/docs/features/datasources/influxdb/
+
+API
+---
+
+Publisher
+`````````
+.. autoclass:: agents.influxdb_publisher.influxdb_publisher.Publisher
+    :members:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Catch InfluxDBServerError's on writes where the InfluxDBServer is down.
* Add support for the InfluxDB "line" protocol, allowing the selection of 'line' or 'json' protocols, mostly for comparison of performance. 'line' is the default and should be used.
* Add support for setting the gzip argument on the InfluxDBClient, compressing data before it is sent across the network to the InfluxDB. This reduces the volume of network traffic at a small performance cost.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

closes #112

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Local testing was performed during development and a development image was run at Penn for the past month without issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
