### PR TITLE
Remove deprecated reparse_args usage

### DIFF
--- a/agents/fake_data/Dockerfile
+++ b/agents/fake_data/Dockerfile
@@ -1,5 +1,5 @@
-# OCS Registry Agent
-# ocs Agent container for running the registry.
+# OCS Fake Data Agent
+# ocs Agent container for generating random data
 
 # Use ocs base image
 FROM ocs:latest
@@ -7,6 +7,7 @@ FROM ocs:latest
 # Set the working directory to registry directory
 WORKDIR /app/ocs/agents/fake_data/
 
+# Copy this agent into the WORKDIR
 COPY . .
 
 # Run registry on container startup

--- a/agents/influxdb_publisher/influxdb_publisher.py
+++ b/agents/influxdb_publisher/influxdb_publisher.py
@@ -140,13 +140,8 @@ if __name__ == '__main__':
     # Start logging
     txaio.start_logging(level=environ.get("LOGLEVEL", "info"))
 
-    parser = site_config.add_arguments()
-
-    parser = make_parser(parser)
-
-    args = parser.parse_args()
-
-    site_config.reparse_args(args, 'InfluxDBAgent')
+    parser = make_parser()
+    args = site_config.parse_args(agent_class='InfluxDBAgent', parser=parser)
 
     agent, runner = ocs_agent.init_site_agent(args)
 

--- a/docs/developer/agents.rst
+++ b/docs/developer/agents.rst
@@ -126,16 +126,13 @@ A simple example of this process can be found in the HWP Simulator Agent:
   if __name__ == '__main__':
 
     # Create an argument parser
-    parser = site_config.add_arguments()
+    parser = argparse.ArgumentParser()
 
     # Tell OCS that the kind of arguments you're adding are for an agent
     pgroup = parser.add_argument_group('Agent Options')
 
-    # Tell OCS to read the arguments
-    args = parser.parse_args()
-
     # Process arguments, choosing the class that matches 'HWPSimulatorAgent'
-    site_config.reparse_args(args, 'HWPSimulatorAgent')
+    args = site_config.parse_args(agent_class='HWPSimulatorAgent', parser=parser)
 
     # Create a session and a runner which communicate over WAMP
     agent, runner = ocs_agent.init_site_agent(args)
@@ -241,13 +238,11 @@ example of a simple Agent.
                                 return False, 'acq is not currently running.'
 
         if __name__ == '__main__':
-                parser = site_config.add_arguments()
+                parser = argparse.ArgumentParser()
 
                 pgroup = parser.add_argument_group('Agent Options')
 
-                args = parser.parse_args()
-
-                site_config.reparse_args(args, 'HWPSimulatorAgent')
+                args = site_config.parse_args(agent_class='HWPSimulatorAgent', parser=parser)
 
                 agent, runnr = ocs_agent.init_site_agent(args)
 

--- a/docs/developer/agents.rst
+++ b/docs/developer/agents.rst
@@ -175,9 +175,9 @@ A simple example of this process can be found in the FakeDataAgent:
     # Run the agent
     runner.run(agent, auto_reconnect=True)
 
-
-If desired, ``pgroup`` may also have arguments (see ``LS240_agent`` for an
-example).
+Here we also set the Agent's commandline arguments using the built in Python
+module ``argparse``. For details on how to using ``argparse`` with OCS see
+:ref:`parse_args`.
 
 Example Agent
 -------------

--- a/docs/developer/site_config.rst
+++ b/docs/developer/site_config.rst
@@ -103,6 +103,7 @@ The structure of InstanceConfig encoding is described in the
     :members: from_dict
     :noindex:
 
+.. _parse_args:
 
 Agent Site-related Command Line Parameters
 ==========================================

--- a/example/nonblocking_ops/example_agent.py
+++ b/example/nonblocking_ops/example_agent.py
@@ -78,9 +78,7 @@ class MyHardwareDevice:
 
 
 if __name__ == '__main__':
-    parser = site_config.add_arguments()
-    args = parser.parse_args()
-    site_config.reparse_args(args, '*host*')
+    args = site_config.parse_args(agent_class='*host*')
 
     agent, runner = ocs_agent.init_site_agent(args)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`site_config.reparse_args()` has been deprecated for a while now, but is still very widely used in socs Agents. This removes it from the only core agent still using it, from one of the examples, and perhaps mostly importantly from the Agent developer documentation.

The one place I haven't removed it from is from ocsbow. I was finding in removing it from some socs Agents that if the Agent still called this line:
```
parser = site_config.add_arguments()
```
to initialize the parser, when `site_config.parse_args()` was later called (which internally calls `site_config.add_arguments()`) we get a conflict error from argparse. Maybe we can discuss how this should be handled here? This PR at least updates examples that might get copied as new Agents are developed. Then an issue can be created if we don't end up handling how `add_arguments()` interacts with things.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's common for new Agents to start from copies of older Agents. This results in the deprecated `reparse_args` being used regularly in new code. Just trying to get things up to date.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've tested that style of change on other Agents, though really I should test these Agents too. I will open this as draft until those are done (likely early next week.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
