### PR TITLE
Clarify the permissions structure for ocs-util

### DIFF
--- a/docker/ocs-util/Dockerfile
+++ b/docker/ocs-util/Dockerfile
@@ -11,5 +11,8 @@ USER ocs:ocs
 ENV JUPYTER_CONFIG_DIR /home/ocs/.jupyter
 COPY --chown=ocs:ocs dot_jupyter /home/ocs/.jupyter
 
+ENV JUPYTER_PORT 8880
+EXPOSE 8880/tcp
+
 ENTRYPOINT ["jupyter", "lab"]
 CMD ["/data"]

--- a/docs/agents/aggregator.rst
+++ b/docs/agents/aggregator.rst
@@ -8,26 +8,11 @@ Aggregator Agent
 
 First Time Setup
 ----------------
-The OCS aggregator agent runs as a user called `ocs`, with a UID of 9000. We
-will setup the same `ocs` user on the host system, as well as an `ocs` group.
-The data written by the aggregator will belong to this user and group::
 
-    $ groupadd -g 9000 ocs
-    $ useradd -u 9000 -g 9000 ocs
-
-Next we need to create the data directory which the aggregator will write files
-to. This can be any directory, however we suggest using ``/data``, and will use
-this in our example::
-
-    $ mkdir /data
-    $ chown 9000:9000 /data
-
-Finally, we should add the current user account to the `ocs` group, replace
-`user` with your current user::
-
-    $ sudo usermod -a -G ocs user
-
-These steps must only be performed once before running the aggregator.
+.. note::
+    Be sure to follow the instructions for :ref:`create_ocs_user` during
+    installation to ensure proper permissions for the Aggregator Agent to write
+    data to disk.
 
 SO3G File Format and Usage
 --------------------------

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -67,3 +67,33 @@ To install, clone the repository and use pip to install::
     on both the pip3 and setup.py commands.
 
 .. _Docker Compose: https://docs.docker.com/compose/install/
+
+.. _create_ocs_user:
+
+Creating the OCS User
+`````````````````````
+If you plan to run OCS within Docker (the recommended configuration) then you
+should create the `ocs` user on your host system as well. This is the user
+that is used within the Docker containers, and creating it on the host will
+allow Agents that write to disk to write to bind mounted volumes within the
+container.
+
+The OCS user, `ocs`, has a UID of 9000, and a matching group, also called
+`ocs`, with a GID of 9000. To create the group and user run::
+
+    $ groupadd -g 9000 ocs
+    $ useradd -u 9000 -g 9000 ocs
+
+Next we need to create the data directory which the aggregator will write files
+to. This can be any directory, for example, ``/data``, which we will use
+throughout this documentation::
+
+    $ mkdir /data
+    $ chown 9000:9000 /data
+
+Finally, we should add the current user account to the `ocs` group, replace
+`user` with your current user::
+
+    $ sudo usermod -a -G ocs user
+
+These steps must only be performed once.

--- a/docs/user/ocs_util.rst
+++ b/docs/user/ocs_util.rst
@@ -10,14 +10,14 @@ Overview
 ========
 
 In many situations you might want to run OCS clients or view so3g data without 
-having to install the software on your local system. The OCS Util docker is a 
-general purpose utility docker which can be used to easily view data or run 
-ocs clients through a jupyter notebook or a command line interface.
+having to install the software on your local system. The ocs-util container is a 
+general purpose utility docker container which can be used to easily view data
+or run ocs clients through a jupyter notebook or a command line interface.
 
 Setup
 =====
 
-The OCS Util docker can be setup by putting the following entry in your system's
+The ocs-util container can be setup by putting the following entry in your system's
 ``docker-compose.yml`` file::
 
   ocs-util:
@@ -32,8 +32,8 @@ The OCS Util docker can be setup by putting the following entry in your system's
     ports:
       - 8880:8880
 
-Then on docker-compose up, the ocs-util docker will automatically start up a 
-jupyter server on port 8880, with a password "password". To change the port,
+Then on docker-compose up, the ocs-util container will automatically start up a 
+Jupyter Lab server on port 8880, with a password "password". To change the port,
 you can change the ``JUPYTER_PORT`` environment variable, and change the 
 ``ports`` entry to expose your chosen port.
 
@@ -42,6 +42,13 @@ you can change the ``JUPYTER_PORT`` environment variable, and change the
     It is highly recommended that you change ``JUPYTER_PW`` to something other than 
     "password", since access to this notebook will give anyone the opportunity to run 
     arbitrary code from the "ocs" user.
+
+.. note::
+
+    The ``/data/`` directory bind mounted to the container needs proper
+    permissions for the Jupyter Lab server to write files to disk. The server runs
+    as the `ocs` user and by default writes to ``/data``. To ensure proper
+    permissions you should for :ref:`create_ocs_user`.
 
 Usage
 =====


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Clarify the permissions structure for ocs-util. Since this requires creating the ocs user, we move that information from the Aggregator Agent page to the more general (and visible) location in the installation instructions.

We also set and expose the same port as is recommended for use in the ocs-util instructions. This should help users who might run the container directly, rather than through docker-compose, else they might run into the situation where they try to access Jupyter via the recommended port 8880, but the service is running on the default 8888.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Clarification prompted by user inquiry.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've setup the ocs-util container with the recommended configuration and can write new Jupyter notebooks to disk.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation fix (updates to documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
