### PR TITLE
Check if args are passed to MatchedClient

### DIFF
--- a/ocs/matched_client.py
+++ b/ocs/matched_client.py
@@ -92,6 +92,9 @@ class MatchedClient:
         For additional kwargs see site_config.get_control_client.
 
         """
+        if kwargs.get('args') is None:
+            kwargs['args'] = []
+
         self._client = site_config.get_control_client(instance_id, **kwargs)
         self.instance_id = instance_id
 

--- a/ocs/matched_client.py
+++ b/ocs/matched_client.py
@@ -79,17 +79,17 @@ class MatchedClient:
     """
 
     def __init__(self, instance_id, **kwargs):
-        """MatchedClient __init__ function.
-
+        """
         Args:
             instance_id (str): Instance id for agent to run
             args (list or args object, optional):
                 Takes in the parser arguments for the client.
-                If None, reads from command line.
+                If None, pass an empty list.
                 If list, reads in list elements as arguments.
                 Defaults to None.
 
-        For additional kwargs see site_config.get_control_client.
+        .. note::
+            For additional ``**kwargs`` see site_config.get_control_client.
 
         """
         if kwargs.get('args') is None:

--- a/tests/test_matched_client.py
+++ b/tests/test_matched_client.py
@@ -1,0 +1,28 @@
+import os
+from unittest.mock import MagicMock, patch
+from ocs.matched_client import MatchedClient
+
+mocked_client = MagicMock()
+mock_from_yaml = MagicMock()
+
+
+@patch('ocs.client_http.ControlClient', mocked_client)
+@patch('ocs.site_config.SiteConfig.from_yaml', mock_from_yaml)
+@patch('sys.argv', ['example_client.py', 'test'])
+def test_extra_argv():
+    """If there are extra arguments in sys.argv and args=[] is not set when
+    instantiating a MatchedClient, then internally
+    site_config.get_control_client() will inspect sys.argv[1:], which causes
+    issues down the line when run through the site_config parser.
+
+    Here we patch in a mocked ControlClient to avoid needing to talk to a
+    crossbar server. We also patch in a mocked from_yaml() method, to avoid
+    needing to read a real site file. Lastly, and most importantly, we patch in
+    sys.argv with an actual additional argument. This will cause an
+    "unrecognized arguments" error when argparse inspects sys.argv within the
+    site_config parser.
+
+    """
+    # Set for get_config to pick up on
+    os.environ["OCS_CONFIG_DIR"] = '/tmp/'
+    MatchedClient("test")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a check when a MatchedClient is instantiated to see if `args` is passed in the `**kwargs`. If it's not, pass `args=[]` when getting the client, preventing inspection of `sys.argv`, which causes the site_config parser some problems.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fixes #176

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I wrote a test that would fail with the `'example_client.py: error: unrecognized arguments: test'` error we'd see if, for example, you tried to write a client that took additional command line arguments. It mocks up a lot, but worked for this test, and now passes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
