### PR TITLE
Deal gracefully with crossbar not being found

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,9 @@ There are also several Python package dependencies, which are listed in the
 
 .. _requirements.txt: requirements.txt
 
+Additionally ``crossbar`` is a required dependency which is not automatically
+installed. It can be installed with pip or run via Docker.
+
 Installation
 ------------
 Clone this repository and install using pip::

--- a/docs/user/dependencies.rst
+++ b/docs/user/dependencies.rst
@@ -32,7 +32,7 @@ Other Dependencies
 * `Docker Compose`_ - CLI tool for running multi-container Docker
   applications.
 
-Crossbar ay be installed via pip if it will be used without Docker; if it
+Crossbar may be installed via pip if it will be used without Docker; if it
 will be used with Docker it does not need to be separately installed.
 
 Operating System

--- a/docs/user/dependencies.rst
+++ b/docs/user/dependencies.rst
@@ -20,17 +20,20 @@ Python Dependencies
 All python dependencies for OCS are listed in (and automatically installed via)
 the ``requirements.txt`` file. Some of the dependencies are:
 
-* `crossbar.io`_ - An implementation of a WAMP router.
 * `Autobahn`_ - Provides open-source implementations of WAMP.
 * `twisted`_ - Used with Autobahn for networking.
 
 Other Dependencies
 ``````````````````
 
+* `crossbar.io`_ - An implementation of a WAMP router.
 * Docker_ - Containerization software used for deploying several SO written
   packages.
 * `Docker Compose`_ - CLI tool for running multi-container Docker
   applications.
+
+Crossbar ay be installed via pip if it will be used without Docker; if it
+will be used with Docker it does not need to be separately installed.
 
 Operating System
 ````````````````

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -134,6 +134,10 @@ class CrossbarConfig:
         self = cls()
         self.parent = parent
         self.binary = data.get('bin', shutil.which('crossbar'))
+        if self.binary is None:
+            raise RuntimeError("Unable to locate crossbar binary")
+        if not os.path.exists(self.binary):
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), self.binary)
         self.cbdir = data.get('config-dir')
         if self.cbdir is None:
             self.cbdir_args = []

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -8,6 +8,7 @@ import yaml
 import argparse
 import collections
 import deprecation
+import errno
 
     
 class SiteConfig:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+crossbar
 autobahn
 twisted
 deprecation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-crossbar
 autobahn
 twisted
 deprecation

--- a/tests/test_site_config.py
+++ b/tests/test_site_config.py
@@ -52,7 +52,7 @@ class TestGetControlClient:
             config = CrossbarConfig.from_dict({})
             assert config.binary == "someplace/bin/crossbar"
 
-        crossbar_not_found = MagicMock()
+        crossbar_not_found = MagicMock(return_value=None)
         with patch("shutil.which", crossbar_not_found), pytest.raises(RuntimeError):
             config = CrossbarConfig.from_dict({})
 

--- a/tests/test_site_config.py
+++ b/tests/test_site_config.py
@@ -1,7 +1,7 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-from ocs.site_config import get_control_client
+from ocs.site_config import get_control_client, CrossbarConfig
 
 
 class TestGetControlClient:
@@ -44,3 +44,17 @@ class TestGetControlClient:
 
         with pytest.raises(ValueError):
             get_control_client('test', site=mock_site, client_type=None)
+
+    def test_missing_crossbar(self):
+        crossbar_found = MagicMock(return_value="someplace/bin/crossbar")
+        with patch("shutils.which", crossbar_found), \
+                patch("os.path.exists", MagicMock(return_value=True)):
+            config = CrossbarConfig.from_dict({})
+            assert config.binary == "someplace/bin/crossbar"
+
+        crossbar_not_found = MagicMock()
+        with patch("shutils.which", crossbar_not_found), pytest.raises(RuntimeError):
+            config = CrossbarConfig.from_dict({})
+
+        with pytest.raises(FileNotFoundError):
+            config = CrossbarConfig.from_dict({"bin": "not/a/valid/path/to/crossbar"})

--- a/tests/test_site_config.py
+++ b/tests/test_site_config.py
@@ -47,13 +47,13 @@ class TestGetControlClient:
 
     def test_missing_crossbar(self):
         crossbar_found = MagicMock(return_value="someplace/bin/crossbar")
-        with patch("shutils.which", crossbar_found), \
+        with patch("shutil.which", crossbar_found), \
                 patch("os.path.exists", MagicMock(return_value=True)):
             config = CrossbarConfig.from_dict({})
             assert config.binary == "someplace/bin/crossbar"
 
         crossbar_not_found = MagicMock()
-        with patch("shutils.which", crossbar_not_found), pytest.raises(RuntimeError):
+        with patch("shutil.which", crossbar_not_found), pytest.raises(RuntimeError):
             config = CrossbarConfig.from_dict({})
 
         with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
Crossbar was not included in requirements.txt, which leads to some obscure errors from a fresh install on a clean system. 

## Description
This patch adds crossbar to requirements.txt so that users should generally not see this problem at all, and adds error checking to detect when crossbar cannot be found at runtime or the user has manually specified an invalid path to it. 

## Motivation and Context
This change prevents or renders more easy to understand problems with crossbar not being found. 

## How Has This Been Tested?
A new unit test is included to verify the behavior of these changes. 
Otherwise, the behavior can be verified by testing installation on any system which does not already have crossbar installed. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.