### PR TITLE
Reorganize Dockerfile to leverage build cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,15 @@ RUN apt-get update && apt-get install -y python3 \
 # Install init system
 RUN pip3 install dumb-init
 
+# Copy in and install requirements
+# This will leverage the cache for rebuilds when modifying OCS, avoiding
+# downloading all the requirements again
+COPY requirements.txt /app/ocs/requirements.txt
+WORKDIR /app/ocs/
+RUN pip3 install -r requirements.txt
+
 # Copy the current directory contents into the container at /app
 COPY . /app/ocs/
 
-WORKDIR /app/ocs/
-
 # Install ocs
-RUN pip3 install -r requirements.txt && \
-    pip3 install -e .
+RUN pip3 install -e .


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add an explicit copy of the requirements file and call the pip install on it
earlier so that on modification of the ocs package we don't have to download
all dependencies again. This'll improve turn around time when iterating on
building OCS Docker images locally for testing during development.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was tired of waiting for PyPI downloads on rebuilds. Official builds will still need to download all packages fresh, as there is no cached image in that environment. So this will only really benefit local builds.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've built the ocs images locally and run a local quickstart setup like in the docs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
