### PR TITLE
Shutdown AggregatorAgent on PermissionError

### DIFF
--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -22,6 +22,8 @@ _g3_list_casts = {
     str: core.G3VectorString, int: core.G3VectorInt, float: core.G3VectorDouble,
 }
 
+LOG = txaio.make_logger()
+
 
 def g3_cast(data, time=False):
     """
@@ -106,7 +108,12 @@ def make_filename(base_dir, make_subdirs=True):
 
     if not os.path.exists(subdir):
         if make_subdirs:
-            os.makedirs(subdir)
+            try:
+                os.makedirs(subdir)
+            except PermissionError as e:
+                LOG.error("Permission error encountered while trying to create "
+                          f"data sub-directory: {e}")
+                raise e
         else:
             raise FileNotFoundError("Subdir {} does not exist"
                                     .format(subdir))

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -138,10 +138,12 @@ class OCSAgent(ApplicationSession):
                 self.log.info("Stopping session {sess}", sess=session)
                 self.log.debug("session details: {sess}",
                                sess=self.sessions[session].encoded())
-                if session in self.tasks:
-                    yield self.abort(session)
-                elif session in self.processes:
-                    yield self.stop(session)
+                # Only try to stop starting or running sessions
+                if self.sessions[session].status not in ['stopping', 'done']:
+                    if session in self.tasks:
+                        yield self.abort(session)
+                    elif session in self.processes:
+                        yield self.stop(session)
         # Give a second for processes to stop cleanly
         yield dsleep(3)
 

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,10 +1,13 @@
+import os
 import time
 import pytest
+
+from unittest.mock import patch
 
 import so3g
 from spt3g import core
 
-from ocs.agent.aggregator import Provider, g3_cast
+from ocs.agent.aggregator import Provider, g3_cast, make_filename
 
 def test_passing_float_in_provider_to_frame():
     """Float is the expected type we should be passing.
@@ -363,3 +366,38 @@ def test_g3_cast():
     for x in incorrect_tests:
         with pytest.raises(TypeError) as e_info:
             g3_cast(x)
+
+
+def test_make_filename_directory_creation(tmpdir):
+    """make_filename() should be able to create directories to store the .g3
+    files in.
+
+    """
+    test_dir = os.path.join(tmpdir, 'data')
+    fname = make_filename(test_dir)
+    # Test we could make the subdir
+    os.path.isdir(os.path.basename(fname))
+
+
+def test_make_filename_directory_creation_no_subdirs(tmpdir):
+    """make_filename() should raise a FileNotFoundError if make_subdirs is
+    False.
+
+    """
+    test_dir = os.path.join(tmpdir, 'data')
+    with pytest.raises(FileNotFoundError):
+        make_filename(test_dir, make_subdirs=False)
+
+
+@patch('os.makedirs', side_effect=PermissionError('mocked permission error'))
+def test_make_filename_directory_creation_permissions(tmpdir):
+    """make_filename() should raise a PermissionError if it runs into one when
+    making the directories.
+
+    Here we mock raising the PermissionError on the makedirs call.
+
+    """
+    test_dir = os.path.join(tmpdir, 'data')
+    with pytest.raises(PermissionError) as e_info:
+        make_filename(test_dir)
+    assert str(e_info.value) == 'mocked permission error'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If the AggregatorAgent is configured to write to a directory that it doesn't have permissions to write to it'll fail when trying to make the directory structure for storing .g3 files. This'll crash the aggregation process, but keep the reactor running. Since this'll nearly always occur at initial Agent startup it would be best to exit the Agent upon seeing this error to make it clear aggregation is not working.

This adds exceptions for the PermissionError close to the error and reraises the error for the Agent to identify and close the reactor when encountered. In adding this shutdown process I was running into a situation where a `stop()` call was being made on the process after it was marked as 'done', this would set the status to 'stopping', which violated the assertion that status only moves forward (https://github.com/simonsobs/ocs/blob/57638df889b0de61a7c6794f55b4f58c02abe8be/ocs/ocs_agent.py#L868). I'm a bit stumped as to why we'd see that, as calling stop on a stopped process should be safe. However, I introduced a check in `_stop_all_running_sessions()` to ensure it only tries to stop tasks/processes that aren't already 'stopping' or 'done'. This avoids the AssertionError raised in `set_status()`. Any insight here is welcome, though the implemented solution seems alright to me too.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #211 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested in an isolated Docker setup with the aggregator and fake data simulator. The data directory was given restrictive permissions to force the PermissionsError. With these restrictive permissions the AggregatorAgent now exits upon error. With proper permissions the Agent behaves as normal.

New unit tests were added for the `make_filename()` function, which was modified in this patch. Integration tests were run, notably for the crossbar reconnection tests and no tests regressed.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
