### PR TITLE
Protect test imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ pytest
 pytest-cov
 docker
 pytest-docker-compose
+pytest-dependency

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,9 @@ msgpack
 influxdb
 PyYAML
 
+# FakeDataAgent
+numpy
+
 # Lakeshore240
 pyserial
 

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -169,6 +169,7 @@ def test_sparsely_sampled_block():
 
 # This is perhaps another problem, I'm passing irregular length data sets and
 # it's not raising any sort of alarm. How does this get handled?
+@pytest.mark.dependency(depends=["so3g"])
 def test_data_type_in_provider_save_to_block():
     provider = Provider('test_provider', 'test_sessid', 3, 1)
     provider.frame_start_time = time.time()
@@ -181,6 +182,7 @@ def test_data_type_in_provider_save_to_block():
     provider.save_to_block(data)
 
 # 'data' field names
+@pytest.mark.dependency(depends=["so3g"])
 def test_passing_invalid_data_field_name1():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -203,6 +205,7 @@ def test_passing_invalid_data_field_name1():
     assert 'invalidkey' in provider.blocks['test'].data.keys()
     assert 'invalid.key' not in provider.blocks['test'].data.keys()
 
+@pytest.mark.dependency(depends=["so3g"])
 def test_passing_invalid_data_field_name2():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -225,6 +228,7 @@ def test_passing_invalid_data_field_name2():
     assert '__invalidkey' in provider.blocks['test'].data.keys()
     assert '__123invalid.key' not in provider.blocks['test'].data.keys()
 
+@pytest.mark.dependency(depends=["so3g"])
 def test_passing_too_long_data_field_name():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -248,6 +252,7 @@ def test_passing_too_long_data_field_name():
 
     assert 'a'*255 in provider.blocks['test'].data.keys()
 
+@pytest.mark.dependency(depends=["so3g"])
 def test_long_duplicate_name():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -272,6 +277,7 @@ def test_long_duplicate_name():
     assert 'a'*255 in provider.blocks['test'].data.keys()
     assert 'a'*252 + '_01' in provider.blocks['test'].data.keys()
 
+@pytest.mark.dependency(depends=["so3g"])
 def test_reducing_to_duplicate_field_names():
     """Invalid data field names get modified by the Aggregator to comply with
     the set rules. This can result in duplicate field names under certain
@@ -299,6 +305,7 @@ def test_reducing_to_duplicate_field_names():
     assert 'aninvalidkey' in provider.blocks['test'].data.keys()
     assert 'aninvalidkey_01' in provider.blocks['test'].data.keys()
 
+@pytest.mark.dependency(depends=["so3g"])
 def test_space_replacement_in_field_names():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -320,6 +327,7 @@ def test_space_replacement_in_field_names():
     assert '_an_invalid_key' in provider.blocks['test'].data.keys()
     assert 'key2' in provider.blocks['test'].data.keys()
 
+@pytest.mark.dependency(depends=["so3g"])
 def test_empty_field_name():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -340,6 +348,7 @@ def test_empty_field_name():
 
     assert '' not in provider.blocks['test'].data.keys()
 
+@pytest.mark.dependency(depends=["so3g"])
 def test_enforced_field_which_becomes_empty():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -386,6 +395,7 @@ def test_g3_cast():
             g3_cast(x)
 
 
+@pytest.mark.dependency(depends=["so3g"])
 def test_make_filename_directory_creation(tmpdir):
     """make_filename() should be able to create directories to store the .g3
     files in.
@@ -397,6 +407,7 @@ def test_make_filename_directory_creation(tmpdir):
     os.path.isdir(os.path.basename(fname))
 
 
+@pytest.mark.dependency(depends=["so3g"])
 def test_make_filename_directory_creation_no_subdirs(tmpdir):
     """make_filename() should raise a FileNotFoundError if make_subdirs is
     False.
@@ -407,6 +418,7 @@ def test_make_filename_directory_creation_no_subdirs(tmpdir):
         make_filename(test_dir, make_subdirs=False)
 
 
+@pytest.mark.dependency(depends=["so3g"])
 @patch('os.makedirs', side_effect=PermissionError('mocked permission error'))
 def test_make_filename_directory_creation_permissions(tmpdir):
     """make_filename() should raise a PermissionError if it runs into one when

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -4,11 +4,25 @@ import pytest
 
 from unittest.mock import patch
 
-import so3g
-from spt3g import core
+try:
+    import so3g
+    from spt3g import core
 
-from ocs.agent.aggregator import Provider, g3_cast, make_filename
+    from ocs.agent.aggregator import Provider, g3_cast, make_filename
+except ModuleNotFoundError as e:
+    print(f"Unable to import either so3g or spt3g: {e}")
 
+
+@pytest.mark.dependency(name="so3g")
+def test_so3g_spt3g_import():
+    """Test that we can import spt3g/so3g. Used to skip tests dependent on
+    these imports.
+
+    """
+    import so3g
+    from spt3g import core
+
+@pytest.mark.dependency(depends=["so3g"])
 def test_passing_float_in_provider_to_frame():
     """Float is the expected type we should be passing.
 
@@ -31,6 +45,7 @@ def test_passing_float_in_provider_to_frame():
 
     provider.to_frame(hksess=sess)
 
+@pytest.mark.dependency(depends=["so3g"])
 def test_passing_float_like_str_in_provider_to_frame():
     """Here we test passing a string amongst ints. This shouldn't make it to
     the aggregator, and instead the Aggregator logs should display an error
@@ -55,6 +70,7 @@ def test_passing_float_like_str_in_provider_to_frame():
 
     provider.to_frame(hksess=sess)
 
+@pytest.mark.dependency(depends=["so3g"])
 def test_passing_non_float_like_str_in_provider_to_frame():
     """Similar to passing a float like str, here we test passing a non-float
     like str. We can't put this into an so3g.IrregBlockDouble(), so this'll fail.
@@ -80,6 +96,7 @@ def test_passing_non_float_like_str_in_provider_to_frame():
 
     provider.to_frame(hksess=sess)
 
+@pytest.mark.dependency(depends=["so3g"])
 def test_sparsely_sampled_block():
     """If a block is sparsely sampled and published, the aggregator was
     including its block_name anyway, even when missing. This test publishes two
@@ -346,6 +363,7 @@ def test_enforced_field_which_becomes_empty():
     assert 'invalid_field_123' in provider.blocks['test'].data.keys()
 
 
+@pytest.mark.dependency(depends=["so3g"])
 def test_g3_cast():
     correct_tests = [
         ([1, 2, 3, 4], core.G3VectorInt),

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -22,6 +22,10 @@ def test_so3g_spt3g_import():
     import so3g
     from spt3g import core
 
+    # Just to avoid flake8 complaining we aren't using these imports
+    print(so3g.__file__)
+    print(core.__file__)
+
 @pytest.mark.dependency(depends=["so3g"])
 def test_passing_float_in_provider_to_frame():
     """Float is the expected type we should be passing.

--- a/tests/test_crossbar_integration.py
+++ b/tests/test_crossbar_integration.py
@@ -9,12 +9,24 @@ import docker
 import numpy as np
 
 from ocs.matched_client import MatchedClient
-from so3g import hk
+
+try:
+    from so3g import hk
+except ModuleNotFoundError as e:
+    print(f"Unable to import so3g: {e}")
 
 # Set OCS_CONFIG_DIR environment variable
 os.environ['OCS_CONFIG_DIR'] = os.getcwd()
 
 pytest_plugins = ("docker_compose",)
+
+@pytest.mark.dependency(name="so3g")
+def test_so3g_spt3g_import():
+    """Test that we can import so3g. Used to skip tests dependent on
+    this import.
+
+    """
+    import so3g
 
 # Fixture to wait for crossbar server to be available.
 @pytest.fixture(scope="function")
@@ -90,6 +102,7 @@ def test_influxdb_publisher_after_crossbar_restart(wait_for_crossbar):
     """
     pass
 
+@pytest.mark.dependency(depends=["so3g"])
 @pytest.mark.integtest
 def test_aggregator_after_crossbar_restart(wait_for_crossbar):
     """Test that the aggregator reconnects after a crossbar restart and that

--- a/tests/test_crossbar_integration.py
+++ b/tests/test_crossbar_integration.py
@@ -28,6 +28,9 @@ def test_so3g_spt3g_import():
     """
     import so3g
 
+    # Just to prevent flake8 from complaining
+    print(so3g.__file__)
+
 # Fixture to wait for crossbar server to be available.
 @pytest.fixture(scope="function")
 def wait_for_crossbar(function_scoped_container_getter):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The HK Aggregator depends on spt3g/so3g, as a result the tests related to the aggregator fail during test collection if spt3g and so3g are not installed. This PR protects the relevant imports and runs a test for those imports. If the import test fails it uses the `pytest-dependency` plugin to skip the so3g/spt3g dependent tests.

This allows other tests to run, while reporting failed tests when an import test is run. For example, on a fresh system with just ocs and the requirements listed in `requirements.txt` installed testing yields:
```
===================================================================== test session starts =====================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /vagrant/ocs, configfile: pytest.ini
plugins: docker-compose-3.2.1, cov-2.12.1, dependency-0.5.1
collected 53 items / 5 deselected / 48 selected

tests/test_aggregator.py Fsssssssssssssssss                                                                                                             [ 37%]
tests/test_crossbar_integration.py F                                                                                                                    [ 39%]
tests/test_influxdb_publisher.py ...                                                                                                                    [ 45%]
tests/test_matched_client.py .                                                                                                                          [ 47%]
tests/test_ocs_feed.py ..............                                                                                                                   [ 77%]
tests/test_pacemaker.py ...                                                                                                                             [ 83%]
tests/test_rename.py ....                                                                                                                               [ 91%]
tests/test_site_config.py ....                                                                                                                          [100%]

========================================================================== FAILURES ===========================================================================
___________________________________________________________________ test_so3g_spt3g_import ____________________________________________________________________

    @pytest.mark.dependency(name="so3g")
    def test_so3g_spt3g_import():
        """Test that we can import spt3g/so3g. Used to skip tests dependent on
        these imports.

        """
>       import so3g
E       ModuleNotFoundError: No module named 'so3g'

tests/test_aggregator.py:22: ModuleNotFoundError
___________________________________________________________________ test_so3g_spt3g_import ____________________________________________________________________

    @pytest.mark.dependency(name="so3g")
    def test_so3g_spt3g_import():
        """Test that we can import so3g. Used to skip tests dependent on
        this import.

        """
>       import so3g
E       ModuleNotFoundError: No module named 'so3g'

tests/test_crossbar_integration.py:29: ModuleNotFoundError
====================================================================== warnings summary =======================================================================
../../usr/lib/python3/dist-packages/twisted/internet/address.py:101
  /usr/lib/python3/dist-packages/twisted/internet/address.py:101: DeprecationWarning: The usage of `cmp` is deprecated and will be removed on or after 2021-06-01.  Please use `eq` and `order` instead.
    @attr.s(hash=False, repr=False, cmp=False)

tests/test_matched_client.py::test_extra_argv
  /vagrant/ocs/ocs/site_config.py:593: DeprecatedWarning: reparse_args is deprecated as of v0.6.0. Use site_config.parse_args instead
    ocs.site_config.reparse_args(args, '*control*')

-- Docs: https://docs.pytest.org/en/stable/warnings.html

---------- coverage: platform linux, python 3.8.10-final-0 -----------
Name                              Stmts   Miss  Cover
-----------------------------------------------------
ocs/__init__.py                       5      0   100%
ocs/agent/__init__.py                 0      0   100%
ocs/agent/aggregator.py             299    299     0%
ocs/agent/influxdb_publisher.py      95     44    54%
ocs/base.py                          14      0   100%
ocs/checkdata.py                    122    122     0%
ocs/client_http.py                   31     17    45%
ocs/client_t.py                      66     35    47%
ocs/matched_client.py                85     68    20%
ocs/ocs_agent.py                    400    329    18%
ocs/ocs_feed.py                     114     16    86%
ocs/ocs_twisted.py                   69     33    52%
ocs/ocsbow.py                       337    337     0%
ocs/rename.py                        49      0   100%
ocs/site_config.py                  268    140    48%
-----------------------------------------------------
TOTAL                              1954   1440    26%

=================================================================== short test summary info ===================================================================
FAILED tests/test_aggregator.py::test_so3g_spt3g_import - ModuleNotFoundError: No module named 'so3g'
FAILED tests/test_crossbar_integration.py::test_so3g_spt3g_import - ModuleNotFoundError: No module named 'so3g'
============================================= 2 failed, 29 passed, 17 skipped, 5 deselected, 2 warnings in 4.71s ==============================================
```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #209.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been run on a fresh Ubuntu 20.04 system with just ocs and the modules listed in the `requirements.txt` file installed. Tests now complete, with failures where so3g imports are tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
