### PR TITLE
Some bug fixes and a bunch of OpSession documentation work

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,11 @@ extensions = [
 ]
 extensions += ['sphinxarg.ext']
 
+# Present auto-documented members in source order (rather than alphabetical).
+autodoc_default_options = {
+    'member-order': 'bysource',
+}
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/developer/clients.rst
+++ b/docs/developer/clients.rst
@@ -190,11 +190,12 @@ Client example would be::
 Replies from Operation methods
 ------------------------------
 
-The responses from Operation methods is a tuple, (status, message,
-session).  The elements of the tuple are:
+The response from Operation methods is a tuple, ``(status, message,
+session)``.  The elements of the tuple are:
 
   ``status``
-    An integer value equal to ocs.OK, ocs.ERROR, or ocs.TIMEOUT.
+    An integer value equal to ocs.OK, ocs.ERROR, or ocs.TIMEOUT (see
+    :class:`ocs.base.ResponseCode`).
 
   ``message``
     A string providing a brief description of the result (this is
@@ -205,8 +206,8 @@ session).  The elements of the tuple are:
     The session information... see below.
 
 Responses obtained from MatchedClient calls are lightly wrapped by
-class ``OCSReply`` so that ``__repr__`` produces a nicely formatted
-description of the result.  For example::
+class :class:`ocs.matched_client.OCSReply` so that ``__repr__``
+produces a nicely formatted description of the result.  For example::
 
   >>> c.set_autoscan.wait()
   OCSReply: OK : Operation "set_autoscan" just exited.
@@ -220,43 +221,16 @@ description of the result.  For example::
 
 
 The ``session`` portion of the reply is dictionary containing a bunch
-of potentially useful information.  This information corresponds to
-the OpSession maintained by the OCSAgent class for each run of an
-Agent's Operation (see OpSession in ocs/ocs_agent.py):
+of potentially useful information, such as timestamps for the
+Operation run's start and end, a success code, and a custom data
+structure populated by the Agent.
 
-  ``'session_id'``
-    An integer identifying this run of the Operation.  If an Op ends
-    and is started again, ``session_id`` will be different.
+The information can be accessed through the OCSReply, for example::
 
-  ``'op_name'``
-    The operation name.  You probably already know this.
+  >>> reply = c.set_autoscan.status()
+  >>> reply.session['start_time']
+  1585667844.423
 
-  ``'status'``
-    A string representing the state of the operation.  The possible
-    values are 'starting', 'running', 'done'.
-
-  ``'start_time'``
-    The timestamp corresponding to when this run was started.
-
-  ``'end_time'``
-    If ``status`` == ``'done'``, then this is the timestamp at which
-    the run completed.  Otherwise it will be None.
-
-  ``'success'``
-    If ``status`` == ``'done'``, then this is a boolean indicating
-    whether the operation reported that it completed successfully
-    (rather than with an error).
-
-  ``'data'``
-    Agent-specific data that might of interest to a user.  This may be
-    updated while an Operation is running, but once ``status`` becomes
-    ``'done'`` then ``data`` should not change any more.  A typical
-    use case here would be for a Process that is monitoring some
-    system to report the current values of key parametrs.  This should
-    not be used as an alternative to providing a data feed... rather
-    it should provide current values to answer immediate questions.
-
-  ``'messages'``
-    A list of Operation log messages.  Each entry in the list is a
-    tuple, (timestamp, text).
-
+For more information on the contents of ``.session``, see the
+docstring for :func:`ocs.ocs_agent.OpSession.encoded`, and the Data
+Access section on :ref:`session_data`.

--- a/docs/developer/session-data.rst
+++ b/docs/developer/session-data.rst
@@ -1,11 +1,14 @@
+.. _session_data:
+
 session.data
 ============
 
 Data Feeds make use of the crossbar Pub/Sub functionality to pass data around
 the network, however, sometimes you might not want to receive all data, just
-the most recent values. For this purpose there is the OpSession data attribute.
-This is per OCS operation location to store recent data of interest to OCS
-Agent users.
+the most recent values. For this purpose there is the ``session.data`` attribute.
+This is a per OCS operation location to store recent data of interest to OCS
+Agent users.  The ``session`` argument passed to each Operation function is an
+object of class :class:`ocs.ocs_agent.OpSession`.
 
 Often this is used to store the most recent values that are queried by the
 Agent, for example the temperature of thermometers on a Lakeshore device. This

--- a/ocs/__init__.py
+++ b/ocs/__init__.py
@@ -1,4 +1,4 @@
-from .base import RET_VALS, OK, ERROR, TIMEOUT
+from .base import OK, ERROR, TIMEOUT, ResponseCode, OpCode
 
 from . import site_config
 

--- a/ocs/base.py
+++ b/ocs/base.py
@@ -1,24 +1,76 @@
 import ocs
 from enum import Enum
 
-RET_VALS = {
-    'OK': 0,
-    'ERROR': -1,
-    'TIMEOUT': 1,
-}
+class ResponseCode(Enum):
+    """Enumeration of response codes from the Operation API (start, stop,
+    wait, ...).
 
-OK = RET_VALS['OK']
-ERROR = RET_VALS['ERROR']
-TIMEOUT = RET_VALS['TIMEOUT']
+    These response codes indicate only whether the API call was
+    successful, in that the request was propagated all the way to the
+    Agent's Operation code.  They are not used to represent success or
+    failure of the Operation itself.
+
+    """
+
+    #: OK indicates the request was successful.
+    OK = 0
+
+    #: ERROR indicates that the request could not be propagated fully.
+    #: This may occur, for example, if an invalid Operation name is
+    #: passed, if request is made that conflicts with an Operation's
+    #: current state (e.g. .start() is called on an already-running
+    #: Operation), if an API call is made to a Operation of an
+    #: incompatible type (e.g. .stop() on a Task), or due to API
+    #: syntax error (e.g. misspelled keyword argument to .wait()).
+    ERROR = -1
+
+    #: TIMEOUT is returned in the case that a Client issued a blocking
+    #: call with timeout (.wait()), and the timeout expired before the
+    #: Operation completed.
+    TIMEOUT = 1
+
+
+OK = ResponseCode.OK.value
+ERROR = ResponseCode.ERROR.value
+TIMEOUT = ResponseCode.TIMEOUT.value
 
 class OpCode(Enum):
+    """Enumeration of OpSession "op_code" values.
+
+    The op_code corresponds to the session.status, except that if the
+    session.status == "done" then the op_code will be assigned a value
+    of either SUCCEEDED or FAILED based on session.success.
+
     """
-    Enumeration of OpSession states.
-    """
+
+    #: NONE is used to represent an uninitialized OpSession, and does
+    #: not correspond to some attempt to run the Operation.
     NONE = 1
+
+    #: STARTING indicates that start() has been successfully called,
+    #: but the Operation has not yet marked itself as successfully
+    #: launched.  If this state is reached, then at the very least the
+    #: start request was not rejected because it was already running.
     STARTING = 2
+
+    #: RUNNING indicates that the Operation has performed its basic
+    #: initialization and parameter checking and is performing its
+    #: task.  Operation codes need to explicitly mark themselves as
+    #: running by calling session.set_state('runnig').
     RUNNING = 3
+
+    #: STOPPING indicates that the Agent has received a stop or abort
+    #: request for this Operation and will try to wrap things up ASAP.
     STOPPING = 4
+
+    #: SUCCEEDED indicates that the Operation has terminated and has
+    #: indicated the Operation was successful.
     SUCCEEDED = 5
+
+    #: FAILED indicates that the Operation has terminated with some
+    #: kind of error.
     FAILED = 6
+
+    #: EXPIRED may used to mark session information as invalid in cases
+    #: where the state cannot be determined.
     EXPIRED = 7

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -832,37 +832,68 @@ class OpSession:
         Returns
         -------
         session_id : int
-          A unique identifier for a single session.
-          When an Operation is initiated, a new session object is
-          created and can be distinguished from other times the
-          Operation has been run using this id.
+          A unique identifier for a single session (a single "run" of
+          the Operation).  When an Operation is initiated, a new
+          session object is created and can be distinguished from
+          other times the Operation has been run using this id.
         op_name : str
           The OCS Operation name.
         op_code : int
           The OpCode, which combines information from status and
-          success; see `ocs.base.ResponseCode`.
+          success; see :class:`ocs.base.ResponseCode`.
         status : str
           The Operation run status (e.g. 'starting', 'done', ...).
-          See SESSION_STATUS_CODES.
+          See :ref:`ocs.ocs_agent.SESSION_STATUS_CODES`.
         success : bool or None
-          If the Operation Session has completed, this indicates that
-          the Operation was deemed successful.  Prior to the
-          completion of the operation, the value is None.
+          If the Operation Session has completed (`status == 'done'`),
+          this indicates that the Operation was deemed successful.
+          Prior to the completion of the operation, the value is None.
+          The value could be False if the Operation reported failure,
+          or if it crashed and failure was marked by the encapsulating
+          OCS code.
         start_time : float
           The time the Operation Session started, as a unix timestamp.
         end_time : float or None
           The time the Operation Session ended, as a unix timestamp.
           While the Session is still on-going, this is None.
         data : dict
+
           This is an area for the Operation code to store custom
-          information that might be of interest to a Control Client,
-          such as the most recent data readings from a device,
-          structured information about the configuration and progress
-          of the Operation, or diagnostics.
+          information that might be of interest to a Control Client
+          (the user), such as the most recent data readings from a
+          device, structured information about the configuration and
+          progress of the Operation, or diagnostics.
+
         messages : list
           A buffer of messages posted by the Operation.  Each element
           of the list is a tuple, (timestamp, message) where timestamp
           is a unix timestamp and message is a string.
+
+        Notes
+        -----
+        This ``data`` field may be used by Agent code to provide data
+        that might be of interest to a user (whether human or
+        automated), such as the most recent readings from a device,
+        structured information about the configuration and progress of
+        the Operation, or diagnostics.
+
+        The structure of the ``data`` entry is not strictly defined,
+        but please observe the following:
+
+        - Document your ``data`` structure in the Operation docstring.
+        - Provide a `timestamp` with the readings, or with each group
+          of readings, so that the consumer can confirm they're
+          recent.
+        - The session data is passed to clients with every API
+          response, so avoid storing a lot of data in there (as a rule
+          of thumb, try to keep it < 100 kB).
+        - Fight the urge to store timestreams (i.e. a history of
+          recent readings) -- try to use data feeds for that.
+        - When data are so useful that they are used by other clients
+          / control scripts to make decisions in automated contexts,
+          then they should also be pushed out to a data feed, so that
+          there is an archive of all variables that were affecting
+          system behavior.
 
         """
         return {'session_id': self.session_id,

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -529,7 +529,7 @@ class OCSAgent(ApplicationSession):
     def _handle_task_error(self, *args, **kw):
         try:
             ex, session = args
-            session.success = ocs.ERROR
+            session.success = False
             session.add_message('Crash in thread: %s' % str(ex))
             session.set_status('done')
         except:

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -272,10 +272,13 @@ class OCSAgent(ApplicationSession):
             return self.start(op_name, params=params)
         if action == 'stop':
             return self.stop(op_name, params=params)
+        if action == 'abort':
+            return self.abort(op_name, params=params)
         if action == 'wait':
             return self.wait(op_name, timeout=timeout)
         if action == 'status':
             return self.status(op_name)
+        return (ocs.ERROR, 'No implementation for "%s"' % op_name, {})
 
     def _gather_sessions(self, parent):
         """Gather the session data for self.tasks or self.sessions, for return
@@ -690,7 +693,7 @@ class OCSAgent(ApplicationSession):
 
           ocs.ERROR: you called a function that does not do anything.
         """
-        return (ocs.ERROR, 'No implementation for operation "%s"' % op_name, {})
+        return (ocs.ERROR, 'No implementation of abort() for operation "%s"' % op_name, {})
 
     def status(self, op_name, params=None):
         """

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -827,10 +827,10 @@ class OpSession:
         status : str
           The Operation run status (e.g. 'starting', 'done', ...).
           See SESSION_STATUS_CODES.
-        success : int or None
-          If the Operation Session has completed, this is an integer
-          with value 0 (OK), -1 (ERROR), or 1 (TIMEOUT).  Prior to the
-          completion of the operation, the value is NOne.
+        success : bool or None
+          If the Operation Session has completed, this indicates that
+          the Operation was deemed successful.  Prior to the
+          completion of the operation, the value is None.
         start_time : float
           The time the Operation Session started, as a unix timestamp.
         end_time : float or None
@@ -850,7 +850,7 @@ class OpSession:
         """
         return {'session_id': self.session_id,
                 'op_name': self.op_name,
-                'op_code': self.op_code,
+                'op_code': self.op_code.value,
                 'status': self.status,
                 'success': self.success,
                 'start_time': self.start_time,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
  
Bug fixes:
- Fix bug that probably caused wait(timeout=None) to report the Operation was completed, return immediately if Operation was "non-blocking" kind.  This is probably the cause of #94  .
- Fix bug where a crash would set session.success to -1 instead of False.
- matched_client wait() accepts timeout argument (should close #189)
- Return well-formatted errors for unimplemented (e.g. abort) or invalid (e.g. shmablort) API calls.

Docs & UI:
- Docs: organize autodoc in source order, not alphabetical.
- Document OpSession.encoded
- Convert base.RET_VALS to an enum.
- Document enums in ocs.base
- Format error & info messages to indicate success/failure more loudly

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

These were issues that emerged while I was starting to address #215 (which is not covered in this PR).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

All tests pass.  I checked local docs builds for proper linking and docstring rendering.  I used FakeDataAgent.delay_task to test changes to wait().

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

The breaking changes boil down to this:
- Perhaps some users rely (perhaps without realizing it) on the buggy behavior of wait().  But I doubt it.  This only affected "non-blocking" ops, which are rare (FakeDataAgent.delay_task happened to be one).
- session.succeeded was set to -1, instead of False, when an Op crashed.  Once again, some users might be checking for that.  But I doubt it.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.

7/7!