### PR TITLE
Param helper

### DIFF
--- a/agents/fake_data/fake_data_agent.py
+++ b/agents/fake_data/fake_data_agent.py
@@ -51,7 +51,7 @@ class FakeDataAgent:
     # Process functions.
 
     @ocs_agent.param('_')  # Reject all params.
-    def start_acq(self, session, params=None):
+    def start_acq(self, session, params):
         """**Process:**  Acquire data and write to the feed.
 
         This Process has no useful parameters.
@@ -157,7 +157,7 @@ class FakeDataAgent:
     # Tasks
     
     @ocs_agent.param('heartbeat', default=True, type=bool)
-    def set_heartbeat_state(self, session, params=None):
+    def set_heartbeat_state(self, session, params):
         """Task to set the state of the agent heartbeat.
 
         Args:
@@ -172,9 +172,9 @@ class FakeDataAgent:
         return True, "Set heartbeat_on: {}".format(heartbeat_state)
 
     @ocs_agent.param('delay', default=5., type=float, check=lambda x: x >= 0)
-    @ocs_agent.param('succeed', default=True)
+    @ocs_agent.param('succeed', default=True, type=bool)
     @inlineCallbacks
-    def delay_task(self, session, params={}):
+    def delay_task(self, session, params):
         """Task that will take the requested number of seconds to complete.
 
         This can run simultaneously with the acq Process.  This Task

--- a/docs/developer/agents.rst
+++ b/docs/developer/agents.rst
@@ -331,6 +331,132 @@ containerized Agents together with the command
 Depending on your host's permissions, this command may need to be run with 
 ``sudo``.
 
+
+Operation Parameters
+--------------------
+
+Many Tasks and Processes will have parameters that are passed in from
+a client when the Operation is inititated.  These are presented to the
+Operation function as the second argument, the ``params`` dictionary.
+The signature of Task and Process start functions is::
+
+   operation_name(self, session, params)
+
+Validation using @param
+^^^^^^^^^^^^^^^^^^^^^^^
+
+It is recommended that Agent developers use the
+:func:`ocs.ocs_agent.param` function decorator to describe all of the
+parameters that are accepted by an Operation start function.
+
+An example of this can be found in the FakeDataAgent::
+
+    @ocs_agent.param('delay', default=5., type=float, check=lambda x: 0 < x < 100)
+    @ocs_agent.param('succeed', default=True)
+    @inlineCallbacks
+    def delay_task(self, session, params={}):
+
+(Note that ``@inlineCallbacks`` is a Twisted thing that is not part of
+parameter decoration.)
+
+Using decorators is optional, but provides benefits to both the Agent
+developer and to the user on the client side.  For the developer, the
+Operation code (the ``delay_task`` function body) may now assume that:
+
+- ``params['delay']`` is set and contains a float with a value between
+  0 and 100.
+- ``params['succeed']`` is set and is a bool.
+- There are no other keys in ``params``.
+
+For the user, any attempt to launch this Operation with invalid
+parameters (e.g. ``delay="seven"`` or ``random_word="brgla"``) will be
+immediately rejected, producing an informative error message::
+
+  >>> client.delay_task(delay='seven')
+  OCSReply: ERROR : Param 'delay'=seven is not of required type (<class 'float'>)
+    (no session -- op has never run)
+
+When using decorators, you have to describe *all* the accepted
+parameters.  The client will be blocked from passing any undefined
+parameters.  To override that behavior (and allow undeclared
+parameters to sail through to the agent), add
+``@ocs_agent.param('_no_check_strays')`` to your decorator set.
+
+If you have a function that accepts no parameters, decorate it with
+``@ocs_agent.param('_')``; that will raise an error for the client if
+they try to pass anything in params.
+
+Here are a few more examples of decorator usage:
+
+  *Require that value passed in has a certain type*::
+
+    @ocs_agent.param('name', type=str)  # Accepts '1.0' but rejects float 1.0
+
+  *Convert incoming data using some casting function*::
+
+    @ocs_agent.param('name', cast=float)  # Accepts '1.0', converts it to float 1.0
+
+  *Require the value to be drawn from a limited set of
+  possibilities*::
+
+    @ocs_agent.param('mode', choices=['current', 'voltage'])  # Rejects other values
+
+  *Require the value to be between 0 and 24; note that if the check
+  fails, the error message returned to user won't be detailed... it
+  will simply say that a validity check failed.  The docstring has to
+  pick up the slack there.*::
+
+    @ocs_agent.param('voltage', check=lambda x: 0 <= x <= 24)
+
+  *If the data is passed in, it must be an integer.  But if not passed
+  in, default to None.*
+
+    @ocs_agent.param('repeat', default=None, type=int)
+
+
+Validation in the Op function
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In the case that more complicated parameter processing is required,
+the Operation code can raise the special
+:class:`ocs.ocs_agent.ParamError` exception to signal failures related
+to parameter processing.  This exception will be caught by the
+encapsulating code and logged as a special failure rather than a
+general crash of the thread.
+
+Here's an example of the implementation in the Agent, for the
+FakeDataAgent ``delay_task``::
+
+  def delay_task(self, session, params):
+      try:
+          delay = float(delay params.get('delay', 5))
+      except ValueError:
+          raise ocs_agent.ParamError("Invalid value for parameter 'delay'")
+
+The @params decorator could have been used in such a simple case.
+In-operation param checking is still necessary sometimes; consider
+this example where the acceptable values of the `'setpoint`' param
+depend on the value the `'mode'` param::
+
+  @ocs_agent.param('mode', choices=['voltage', 'current'])
+  @ocs_agent.param('setpoint', type=float)
+  def set_level(self, session, params):
+      if params['mode'] == 'voltage' and params['setpoint'] > 24.:
+          raise ocs_agent.ParamError("Setpoint must be <= 24 in 'voltage' mode.")
+      if params['mode'] == 'current' ad params['setpoint'] > 2.:
+          raise ocs_agent.ParamError("Setpoint must be <= 2 in 'current' mode.")
+
+Prior to the introduction of ``@params`` and ``ParamError`` in OCS,
+params needed to be checked individually, and failures propagated back
+manually.  For example::
+
+  def delay_task(self, session, params):
+      try:
+          delay = float(delay params.get('delay', 5))
+      except ValueError:
+          return False, "Invalid value for parameter 'delay'"
+
+
 .. _timeout_lock:
 
 TimeoutLock

--- a/docs/developer/agents.rst
+++ b/docs/developer/agents.rst
@@ -352,15 +352,15 @@ parameters that are accepted by an Operation start function.
 An example of this can be found in the FakeDataAgent::
 
     @ocs_agent.param('delay', default=5., type=float, check=lambda x: 0 < x < 100)
-    @ocs_agent.param('succeed', default=True)
+    @ocs_agent.param('succeed', default=True, type=bool)
     @inlineCallbacks
-    def delay_task(self, session, params={}):
+    def delay_task(self, session, params):
 
 (Note that ``@inlineCallbacks`` is a Twisted thing that is not part of
 parameter decoration.)
 
 Using decorators is optional, but provides benefits to both the Agent
-developer and to the user on the client side.  For the developer, the
+developer and to the user on the Client side.  For the developer, the
 Operation code (the ``delay_task`` function body) may now assume that:
 
 - ``params['delay']`` is set and contains a float with a value between
@@ -409,7 +409,7 @@ Here are a few more examples of decorator usage:
     @ocs_agent.param('voltage', check=lambda x: 0 <= x <= 24)
 
   *If the data is passed in, it must be an integer.  But if not passed
-  in, default to None.*
+  in, default to None.*::
 
     @ocs_agent.param('repeat', default=None, type=int)
 
@@ -429,7 +429,7 @@ FakeDataAgent ``delay_task``::
 
   def delay_task(self, session, params):
       try:
-          delay = float(delay params.get('delay', 5))
+          delay = float(params.get('delay', 5))
       except ValueError:
           raise ocs_agent.ParamError("Invalid value for parameter 'delay'")
 
@@ -452,7 +452,7 @@ manually.  For example::
 
   def delay_task(self, session, params):
       try:
-          delay = float(delay params.get('delay', 5))
+          delay = float(params.get('delay', 5))
       except ValueError:
           return False, "Invalid value for parameter 'delay'"
 

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -1023,7 +1023,7 @@ class ParamHandler:
             @ocs_agent.param('voltage', type=float)
             @ocs_agent.param('delay_time', default=1., type=float)
             @ocs_agent.param('other_action', default=None, cast=str)
-            def my_task(self, session, params={}):
+            def my_task(self, session, params):
                 # (Type checking and default substitution have been done already)
                 voltage = params['voltage']
                 delay_time = params['delay_time']
@@ -1032,7 +1032,7 @@ class ParamHandler:
 
     When you use the @param decorator, the OCS code can check the
     parameters immediately when they are received from the client, and
-    immediatley return an error message to the client's start reequest
+    immediately return an error message to the client's start request
     (without even calling the Op start function)::
 
         OCSReply: ERROR : Param 'delay'=two_seconds is not of required type (<class 'float'>)
@@ -1047,7 +1047,7 @@ class ParamHandler:
 
         class MyAgent:
             ...
-            def my_task(self, session, params={}):
+            def my_task(self, session, params):
                 params = ocs_agent.ParamHandler(params)
                 # Mandatory, and cannot be None.
                 voltage = params.get('voltage', type=float)
@@ -1082,8 +1082,8 @@ class ParamHandler:
         found to be missing, or its value not valid, then a ParamError
         is raised.
 
-        In Agent Op implementatations, the ParamError will be caught
-        by the API wrapper and automatically propagated to the caller.
+        In Agent Op implementations, the ParamError will be caught by
+        the API wrapper and automatically propagated to the caller.
         The Operation session will be marked as "done", with
         success=False.
 
@@ -1103,8 +1103,8 @@ class ParamHandler:
           returns False then a ParamError will be raised.
         cast : callable
           A function to run on the value to convert it.  For example
-          cast=str.lower would help convert user argument "Voltage" to
-          value "voltage".
+          ``cast=str.lower`` would help convert user argument
+          "Voltage" to value "voltage".
         type : type
           Class to which the result will be compared, unless it is
           ``None``.  Note that if you pass ``type=float``, ``int``
@@ -1135,9 +1135,10 @@ class ParamHandler:
         ``{}`` while allowing ``{'param': None}`` to be taken at face
         value, then set ``treat_none_as_missing=False``.
 
-        Note that the type checking and the cast and check functions
-        are only activated if the value (or the substituted default
-        value) is not ``None``.
+        The cast function, if specified, is applied before the type,
+        choices, and check arguments are processed.  If the value (or
+        the substituted default value) is ``None``, then any specified
+        cast and checks will not be performed.
 
         """
         self._checked.add(key)
@@ -1208,8 +1209,9 @@ def param(key, **kwargs):
           ...
 
     Note the ``@param`` decorators should be all together, and
-    outermost (listed first).  ``@inlineCallbacks``, if in use, should
-    be the last decorator.
+    outermost (listed first).  This is because the current
+    implementation caches data in the decorated function (or
+    generator) directly, and additional decorators will conceal that.
 
     See :class:`ocs.ocs_agent.ParamHandler` for more details.  Note the
     signature for @param is the same as for :func:`ParamHandler.get`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Introduces a way to describe Operation parameters, to help with type checking, setting defaults, validity checking, and returning useful error messages to the caller.  The API handling code can check the user-supplied parameters when start() is called, prior to returning the initial response, which means the user gets faster feedback that their params were ok/not ok.

This is purely an enhancement; shouldn't break existing Agents.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is useful on the Agent side because boiler-plate for parameter checking, setting defaults, etc, is avoided.  It is useful on the client side because typos and other call syntax errors will be rejected immediately with an informative error message instead of seeming to succeed and/or crashing the Operation thread.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

FakeDataAgent has been extended to use the `@param` decorator, and tested in a miniobs using MatchedClient.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
