### PR TITLE
Only perform check on param if value is given

### DIFF
--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -1164,9 +1164,9 @@ class ParamHandler:
             if choices is not None:
                 if value not in choices:
                     raise ParamError(f"Param '{key}'={value} is not in allowed set ({choices})")
-        if check is not None:
-            if not check(value):
-                raise ParamError(f"Param '{key}' failed validity check (see docs?).")
+            if check is not None:
+                if not check(value):
+                    raise ParamError(f"Param '{key}' failed validity check (see docs?).")
         return value
 
     def batch(self, instructions, check_for_strays=True):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If a value isn't given, the check likely isn't valid. This will cause problems
if the decorated method is imported, for instance in any testing, as the value
will be None on import, which will fail simple checks like x < 100.

Example traceback when this happens:
```
tests/agents/test_ls372_agent.py:3: in <module>                                      
    from LS372_agent import LS372_Agent                                              
agents/lakeshore372/LS372_agent.py:70: in <module>                                   
    class LS372_Agent:                                                               
agents/lakeshore372/LS372_agent.py:585: in LS372_Agent                               
    ???                                                                              
../ocs/ocs/ocs_agent.py:1224: in param                                               
    ParamHandler({}).get(key, default=None, **kwargs)                                
../ocs/ocs/ocs_agent.py:1168: in get                                                 
    if not check(value):                                                             
agents/lakeshore372/LS372_agent.py:585: in <lambda>                                  
    ???                                                                              
E   TypeError: '<' not supported between instances of 'NoneType' and 'int'   
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
No open issue for this bug, found when developing tests for an socs Agent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The import in question above passes with this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
