### PR TITLE
Update feed message data check to handle bools

### DIFF
--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -253,9 +253,11 @@ class Feed:
         """
         valid_types = (float, int, str)
 
+        # separate bool checks since bool is a subclass of int
         # multi-sample check
         if isinstance(value, list):
-            if not all(isinstance(x, valid_types) for x in value):
+            if (any(isinstance(x, bool) for x in value)
+                    or not all(isinstance(x, valid_types) for x in value)):
                 type_set = set([type(x) for x in value])
                 invalid_types = type_set.difference(valid_types)
                 raise TypeError("message 'data' block contains invalid data" +
@@ -263,7 +265,7 @@ class Feed:
 
         # single sample check
         else:
-            if not isinstance(value, valid_types):
+            if isinstance(value, bool) or not isinstance(value, valid_types):
                 invalid_type = type(value)
                 raise TypeError("message 'data' block contains invalid " +
                                 f"data type: {invalid_type}")

--- a/tests/test_ocs_feed.py
+++ b/tests/test_ocs_feed.py
@@ -64,6 +64,36 @@ class TestPublishMessage:
 
         test_feed.publish_message(test_message)
 
+    def test_bool_single_sample_input(self):
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        test_message = {
+            'block_name': 'test',
+            'timestamp': time.time(),
+            'data': {
+                'key1': True,
+            }
+        }
+
+        with pytest.raises(TypeError):
+            test_feed.publish_message(test_message)
+
+    def test_bool_multi_sample_input(self):
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        test_message = {
+            'block_name': 'test',
+            'timestamps': [time.time(), time.time()+1, time.time()+2],
+            'data': {
+                'key1': [True, False, True],
+            }
+        }
+
+        with pytest.raises(TypeError):
+            test_feed.publish_message(test_message)
+
     def test_str_multi_sample_input(self):
         """Passing multiple points, including invalid datatypes,
         should cause a TypeError upon publishing.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If a `bool` is published to an OCS Feed it'll pass the data verification method that checks that data is of type `(float, int, str)` since `bool` is a subclass of `int`. Downstream this'll cause errors in the Aggregator (the Aggregator casts to a G3 type, sees it can't handle this data and drops it).

This patch will raise a `TypeError` on the Agent end if a `bool` is published.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This issue was identified by @sanahabhimani on the system at Yale when a `bool` was making it to the Aggregator Agent. The Aggregator then continuously produced the error:
```
2021-10-05T20:00:02+0000 Error received when casting timestream! g3_cast does not support type <class 'bool'>. Type mustbe one of dict_keys([<class 'str'>, <class 'int'>, <class 'float'>])
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Two tests have been added, asserting that the `TypeError` is raised when `bool`'s are passed either as a single sample, or in a list.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
