### PR TITLE
Core updates, prelude for major ocsbow

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -59,6 +59,7 @@ ocs.ocs_agent
 .. automodule:: ocs.ocs_agent
     :members:
     :undoc-members:
+    :private-members:
     :show-inheritance:
 
 .. _ocs_feed_api:

--- a/ocs/client_http.py
+++ b/ocs/client_http.py
@@ -40,14 +40,18 @@ class ControlClient():
         return decoded['args'][0]
 
     def get_api(self, simple=False):
-        """Query the API from the Agent; this includes lists of Processes,
-        Tasks, and Feeds exposed by the agent, and their current
-        session information.
+        """Query the API and other info from the Agent; this includes lists of
+        Processes, Tasks, and Feeds, docstrings, operation session
+        structures, and info about the Agent instance (class, PID,
+        host).
 
-        See :func:`ocs.ocs_agent.OCSAgent._management_handler`
+        Args:
+          simple (bool): If True, then return just the lists of the op
+            and feed names without accompanying detail.
 
-        If simple=True, then return just lists of the op & feed names
-        without accompanying detail.
+        Returns:
+          A dict, see :func:`ocs.ocs_agent.OCSAgent._management_handler`
+          for detail.
 
         """
         data = self.call(self.agent_addr, 'get_api')

--- a/ocs/client_http.py
+++ b/ocs/client_http.py
@@ -36,7 +36,22 @@ class ControlClient():
             raise RuntimeError([0,0,0,0,decoded['error'],decoded['args'],decoded['kwargs']])
         return decoded['args'][0]
 
-    # These are API we want to add.
+    def get_api(self, simple=False):
+        """Query the API from the Agent; this includes lists of Processes,
+        Tasks, and Feeds exposed by the agent, and their current
+        session information.
+
+        See :func:`ocs.ocs_agent.OCSAgent._management_handler`
+
+        If simple=True, then return just lists of the op & feed names
+        without accompanying detail.
+
+        """
+        data = self.call(self.agent_addr, 'get_api')
+        if not simple:
+            return data
+        return {k: [_v[0] for _v in v]
+                for k, v in data.items() if isinstance(v, dict)}
 
     def get_tasks(self):
         """

--- a/ocs/client_http.py
+++ b/ocs/client_http.py
@@ -2,6 +2,9 @@
 import json
 import requests
 
+class ControlClientError(RuntimeError):
+    pass
+
 class ControlClient():
     def __init__(self, agent_addr, **kwargs):
         self.agent_addr = agent_addr
@@ -25,15 +28,15 @@ class ControlClient():
         try:
             r = requests.post(self.call_url, data=params)
         except requests.exceptions.ConnectionError as e:
-            raise RuntimeError([0,0,0,0,'client_http.error.connection_error',
-                                ['Failed to connect to %s' % self.call_url], {}])
+            raise ControlClientError([0,0,0,0,'client_http.error.connection_error',
+                                      ['Failed to connect to %s' % self.call_url], {}])
         if r.status_code != 200:
-            raise RuntimeError([0,0,0,0,'client_http.error.request_error',
-                                ['Server replied with code %i' % r.status_code], {}])
+            raise ControlClientError([0,0,0,0,'client_http.error.request_error',
+                                      ['Server replied with code %i' % r.status_code], {}])
         decoded = r.json()
         if 'error' in decoded:
             # Return errors in the same way wampy does, roughly.
-            raise RuntimeError([0,0,0,0,decoded['error'],decoded['args'],decoded['kwargs']])
+            raise ControlClientError([0,0,0,0,decoded['error'],decoded['args'],decoded['kwargs']])
         return decoded['args'][0]
 
     def get_api(self, simple=False):

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -18,6 +18,7 @@ from autobahn.exception import Disconnected
 from .ocs_twisted import in_reactor_context
 
 import time, datetime
+import socket
 import os
 from deprecation import deprecated
 from ocs import client_t
@@ -344,7 +345,9 @@ class OCSAgent(ApplicationSession):
                 'tasks': self._gather_sessions(self.tasks),
                 'processes': self._gather_sessions(self.processes),
                 'feeds': [(k, v.encoded()) for k, v in self.feeds.items()],
-                'agent_class': self.class_name
+                'agent_class': self.class_name,
+                'instance_hostname': socket.gethostname(),
+                'instance_pid': os.getpid(),
             }
         if q == 'get_tasks':
             return self._gather_sessions(self.tasks)

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -329,25 +329,29 @@ class OCSAgent(ApplicationSession):
           entries is returned:
 
           - 'agent_class': The class name of this agent.
+          - 'instance_hostname': The host name where the Agent is
+            running, as returned by socket.gethostname().
+          - 'instance_pid': The PID of the Agent interpreter session,
+            as returned by os.getpid().
           - 'feeds': The list of encoded feed information, tuples
             (feed_name, feed_info).
-          - 'tasks': The list of Task api description info, as
-            returned by :func:`_gather_sessions`.
           - 'processes': The list of Process api description info, as
             returned by :func:`_gather_sessions`.
+          - 'tasks': The list of Task api description info, as
+            returned by :func:`_gather_sessions`.
 
-          Passing get_X will return only that subset of the full API.
-          Maybe don't use those.
+          Passing get_X will, for some values of X, return only that
+          subset of the full API; treat that as deprecated.
 
         """
         if q == 'get_api':
             return {
-                'tasks': self._gather_sessions(self.tasks),
-                'processes': self._gather_sessions(self.processes),
-                'feeds': [(k, v.encoded()) for k, v in self.feeds.items()],
                 'agent_class': self.class_name,
                 'instance_hostname': socket.gethostname(),
                 'instance_pid': os.getpid(),
+                'feeds': [(k, v.encoded()) for k, v in self.feeds.items()],
+                'processes': self._gather_sessions(self.processes),
+                'tasks': self._gather_sessions(self.tasks),
             }
         if q == 'get_tasks':
             return self._gather_sessions(self.tasks)

--- a/ocs/ocs_client.py
+++ b/ocs/ocs_client.py
@@ -102,13 +102,13 @@ class OCSClient:
 
         self._client = site_config.get_control_client(instance_id, **kwargs)
         self.instance_id = instance_id
-        api = self._client.get_api()
+        self._api = self._client.get_api()
 
-        for name, session, encoded in api['tasks']:
+        for name, session, encoded in self._api['tasks']:
             setattr(self, _opname_to_attr(name),
                     _get_op('task', name, encoded, self._client))
 
-        for name, session, encoded in api['processes']:
+        for name, session, encoded in self._api['processes']:
             setattr(self, _opname_to_attr(name),
                     _get_op('process', name, encoded, self._client))
 

--- a/ocs/ocs_client.py
+++ b/ocs/ocs_client.py
@@ -102,12 +102,13 @@ class OCSClient:
 
         self._client = site_config.get_control_client(instance_id, **kwargs)
         self.instance_id = instance_id
+        api = self._client.get_api()
 
-        for name, _, encoded in self._client.get_tasks():
+        for name, session, encoded in api['tasks']:
             setattr(self, _opname_to_attr(name),
                     _get_op('task', name, encoded, self._client))
 
-        for name, _, encoded in self._client.get_processes():
+        for name, session, encoded in api['processes']:
             setattr(self, _opname_to_attr(name),
                     _get_op('process', name, encoded, self._client))
 

--- a/ocs/ocs_client.py
+++ b/ocs/ocs_client.py
@@ -104,11 +104,11 @@ class OCSClient:
         self.instance_id = instance_id
         self._api = self._client.get_api()
 
-        for name, session, encoded in self._api['tasks']:
+        for name, _, encoded in self._api['tasks']:
             setattr(self, _opname_to_attr(name),
                     _get_op('task', name, encoded, self._client))
 
-        for name, session, encoded in self._api['processes']:
+        for name, _, encoded in self._api['processes']:
             setattr(self, _opname_to_attr(name),
                     _get_op('process', name, encoded, self._client))
 

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -149,7 +149,6 @@ class CrossbarConfig:
         if not os.path.exists(self.binary):
             raise RuntimeError("The crossbar binary specified in site_config "
                                "does not seem to exist: %s" % self.binary)
-            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), self.binary)
         return [self.binary, cmd] + self.cbdir_args
 
     def summary(self):

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -494,7 +494,8 @@ def get_config(args, agent_class=None):
                     dev, parent=host_config)
     if instance_config is None and not no_dev_match:
         raise RuntimeError("Could not find matching device description.")
-    return (site_config, host_config, instance_config)
+    return collections.namedtuple('SiteConfig', ['site', 'host', 'instance'])\
+        (site_config, host_config, instance_config)
 
 
 def add_site_attributes(args, site, host=None):

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -135,10 +135,6 @@ class CrossbarConfig:
         self = cls()
         self.parent = parent
         self.binary = data.get('bin', shutil.which('crossbar'))
-        if self.binary is None:
-            raise RuntimeError("Unable to locate crossbar binary")
-        if not os.path.exists(self.binary):
-            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), self.binary)
         self.cbdir = data.get('config-dir')
         if self.cbdir is None:
             self.cbdir_args = []
@@ -147,6 +143,13 @@ class CrossbarConfig:
         return self
 
     def get_cmd(self, cmd):
+        if self.binary is None:
+            raise RuntimeError("Crossbar binary could not be found in PATH; "
+                               "specify the binary in site_config?")
+        if not os.path.exists(self.binary):
+            raise RuntimeError("The crossbar binary specified in site_config "
+                               "does not seem to exist: %s" % self.binary)
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), self.binary)
         return [self.binary, cmd] + self.cbdir_args
 
     def summary(self):

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -231,16 +231,17 @@ class InstanceConfig:
 
         ``arguments`` (list, optional):
             A list of arguments that should be passed back to the
-            agent.  Each element of the list should be a pair of
-            strings, like ``['--option-name', 'value']``.  This is not
-            as general as one might like, but is required in the
-            current scheme.
+            agent.  Historically the arguments have been grouped into
+            into key value pairs, e.g. [['--key1', 'value'],
+            ['--key2', 'value']] but these days whatever you passed in
+            gets flattened to a single list (i.e. that is equivalent
+            to ['--key1', 'value', '--key2', 'value'].
 
         """
         self = cls()
         self.parent = parent
         self.data = data
-        self.arguments = self.data['arguments']
+        self.arguments = self.data.get('arguments', [])
         return self
 
 

--- a/tests/test_site_config.py
+++ b/tests/test_site_config.py
@@ -52,9 +52,14 @@ class TestGetControlClient:
             config = CrossbarConfig.from_dict({})
             assert config.binary == "someplace/bin/crossbar"
 
+        # CrossbarConfig should only raise errors if someone tries to
+        # use the invalid config.
         crossbar_not_found = MagicMock(return_value=None)
-        with patch("shutil.which", crossbar_not_found), pytest.raises(RuntimeError):
+        with patch("shutil.which", crossbar_not_found):
             config = CrossbarConfig.from_dict({})
+        with pytest.raises(RuntimeError):
+            config.get_cmd('start')
 
-        with pytest.raises(FileNotFoundError):
-            config = CrossbarConfig.from_dict({"bin": "not/a/valid/path/to/crossbar"})
+        config = CrossbarConfig.from_dict({"bin": "not/a/valid/path/to/crossbar"})
+        with pytest.raises(RuntimeError):
+            config.get_cmd('start')

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,5 @@
 from unittest.mock import MagicMock
-
+import os
 
 def fake_get_control_client(instance_id, **kwargs):
     """Quick function to return a Client like you'd expect from
@@ -9,12 +9,20 @@ def fake_get_control_client(instance_id, **kwargs):
     """
     encoded_op = {'blocking': True,
                   'docstring': 'Example docstring'}
-    client = MagicMock()
-    client.get_tasks = MagicMock(return_value=([('task_name',
-                                               None,
-                                               encoded_op)]))
-    client.get_processes = MagicMock(return_value=([('process_name',
-                                                     None,
-                                                     encoded_op)]))
+    client = MagicMock()  # mocks client_http.ControlClient
+
+    # The api structure is defined by OCSAgent._management_handler
+    api = {
+        'tasks': [('task_name', None, encoded_op)],
+        'processes': [('process_name', None, encoded_op)],
+        'feeds': [],
+        'agent_class': 'Mock',
+        'instance_hostname': 'testhost',
+        'instance_pid': os.getpid(),
+        }
+
+    client.get_tasks = MagicMock(return_value=api['tasks'])
+    client.get_processes = MagicMock(return_value=api['processes'])
+    client.get_api = MagicMock(return_value=api)
 
     return client


### PR DESCRIPTION
## Description
Innocuous (I think) improvements that are helpful to upcoming ocsbow/HostManager revamp.  This will be followed by a major ocsbow/HostManager PR that has only one additional core change (adding 'manage' as an instance argument in site_config).

Includes:
* Fix for #237 
* Fix for #224 
* site_config.get_config returns namedtuple(site, host, instance)
* 'arguments' is not required for agent instance blocks in site_config file.

## How Has This Been Tested?

Used for extensive ocsbow work.  All tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
