### PR TITLE
Remove spt3g/so3g dependency from the Registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ RUN pip3 install -r requirements.txt
 COPY . /app/ocs/
 
 # Install ocs
-RUN pip3 install -e .
+RUN pip3 install .

--- a/agents/registry/registry.py
+++ b/agents/registry/registry.py
@@ -6,8 +6,6 @@ from autobahn.twisted.util import sleep as dsleep
 from collections import defaultdict
 from ocs.ocs_feed import Feed
 
-from ocs.agent.aggregator import Provider
-
 class RegisteredAgent:
     """
         Contains data about registered agents.
@@ -166,7 +164,7 @@ class Registry:
                     field = f'{addr}_{op_name}'
                     field = field.replace('.', '_')
                     field = field.replace('-', '_')
-                    field = Provider._enforce_field_name_rules(field)
+                    field = Feed.enforce_field_name_rules(field)
                     try:
                         Feed.verify_data_field_string(field)
                     except ValueError as e:

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -325,3 +325,54 @@ class Feed:
                              "exceeds the valid length of 255 characters.")
 
         return True
+
+    @staticmethod
+    def enforce_field_name_rules(field_name):
+        """Enforce naming rules for field names.
+
+        A valid name:
+
+        * contains only letters (a-z, A-Z; case sensitive), decimal digits (0-9), and the
+          underscore (_).
+        * begins with a letter, or with any number of underscores followed by a letter.
+        * is at least one, but no more than 255, character(s) long.
+
+        Args:
+            field_name (str):
+                Field name string to check and modify if needed.
+
+        Returns:
+            str: New field name, meeting all above rules. Note this isn't
+                 guarenteed to not collide with other field names passed
+                 through this method, and that should be checked.
+
+        """
+        # check for empty string
+        if field_name == "":
+            new_field_name = "invalid_field"
+        else:
+            new_field_name = field_name
+
+        # replace spaces with underscores
+        new_field_name = new_field_name.replace(' ', '_')
+
+        # replace invalid characters
+        new_field_name = re.sub('[^a-zA-Z0-9_]', '', new_field_name)
+
+        # grab leading underscores
+        underscore_search = re.compile('^_*')
+        underscores = underscore_search.search(new_field_name).group()
+
+        # remove leading underscores
+        new_field_name = re.sub('^_*', '', new_field_name)
+
+        # remove leading non-letters
+        new_field_name = re.sub('^[^a-zA-Z]*', '', new_field_name)
+
+        # add underscores back
+        new_field_name = underscores + new_field_name
+
+        # limit to 255 characters
+        new_field_name = new_field_name[:255]
+
+        return new_field_name

--- a/tests/agents/test_registry_agent.py
+++ b/tests/agents/test_registry_agent.py
@@ -7,18 +7,11 @@ import pytest_twisted
 
 from agents.util import create_session, create_agent_fixture
 
+from registry import Registry
 
-try:
-    # depends on spt3g
-    from registry import Registry
-
-    agent = create_agent_fixture(Registry)
-except ModuleNotFoundError as e:
-    print(f"Unable to import: {e}")
+agent = create_agent_fixture(Registry)
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=['so3g'], scope='session')
 class TestMain:
     @pytest_twisted.inlineCallbacks
     def test_registry_main(self, agent):
@@ -79,8 +72,6 @@ class TestMain:
         assert session.data['observatory.test_agent']['op_codes'] == expected_op_codes
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=['so3g'], scope='session')
 class TestStopMain:
     def test_registry_stop_main_while_running(self, agent):
         session = create_session('main')
@@ -97,8 +88,6 @@ class TestStopMain:
         assert res[0] is False
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=['so3g'], scope='session')
 def test_registry_register_agent(agent):
     session = create_session('main')
     agent_data = {'agent_address': 'observatory.test_agent'}

--- a/tests/integration/test_registry_agent_integration.py
+++ b/tests/integration/test_registry_agent_integration.py
@@ -20,7 +20,6 @@ run_agent = create_agent_runner_fixture('../agents/registry/registry.py',
 client = create_client_fixture('registry')
 
 
-@pytest.mark.dependency(depends=["so3g"], scope='session')
 @pytest.mark.integtest
 def test_registry_agent_main(wait_for_crossbar, run_agent, client):
     # Startup is always true, so let's check it's running


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This moves `_enforce_field_name_rules()` out of the Aggregator agent part of the ocs library and into the `Feed` class, where similar field related static methods are. This eliminates the dependency of spt3g/so3g on the Registry Agent.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #239

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The full test suite was run after the move. Also tested on a system without an spt3g/so3g installation (with `-m 'not spt3g'`) to verify that Registry tests no longer depend on spt3g/so3g.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
