### PR TITLE
Task abort and other stop fix-ups

### DIFF
--- a/docs/developer/clients.rst
+++ b/docs/developer/clients.rst
@@ -40,8 +40,7 @@ Process (referred to generally "Operation") exposed by the OCS Agent with the
 specified ``agent-instance-id``. Each of these attributes has a set of methods
 associated with them for controlling the Operation. The methods for running an
 Agent's Operations are described in :ref:`agent_ops`. They are "start",
-"status", "wait", and "stop" ("abort" is not implemented at the time of this
-writing.)
+"status", "wait", "stop" (Process only) and "abort" (Task only).
 
 Once the Client is instantiated, Operations can be commanded, for example, to
 start a Process called 'acq' (a common Process name for beginning data

--- a/docs/developer/writing_an_agent/process.rst
+++ b/docs/developer/writing_an_agent/process.rst
@@ -1,3 +1,5 @@
+.. _adding_a_process:
+
 Adding a Process
 ----------------
 

--- a/docs/developer/writing_an_agent/task.rst
+++ b/docs/developer/writing_an_agent/task.rst
@@ -96,8 +96,8 @@ function, which typically will look like this:
             session.set_status('stopping')
 
 Within the Task function, at points that are reasonable to request an abort,
-you must add a check of the ``session.status`` that then exits the Task if the
-status is no longer running. For example:
+you must add a check of the ``session.status`` that then exits the Task with an
+error (i.e. returns ``False``) if the status is no longer running. For example:
 
 .. code-block:: python
 
@@ -106,7 +106,9 @@ status is no longer running. For example:
 
 Where you insert this interrupt code will vary from Agent to Agent. Tasks that
 run quickly do not need an abort to be implemented at all. However, for long
-running Tasks abort should be implemented.
+running Tasks abort should be implemented. (We will see this interruption
+implementation again in the next step where we discuss
+:ref:`adding_a_process`.)
 
 When registering the Task, the aborter must be specified:
 

--- a/ocs/agents/fake_data/agent.py
+++ b/ocs/agents/fake_data/agent.py
@@ -7,7 +7,7 @@ import txaio
 from os import environ
 import numpy as np
 from autobahn.wamp.exception import ApplicationError
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from autobahn.twisted.util import sleep as dsleep
 
 # For logging

--- a/ocs/agents/fake_data/agent.py
+++ b/ocs/agents/fake_data/agent.py
@@ -207,7 +207,8 @@ class FakeDataAgent:
     def delay_task(self, session, params):
         """delay_task(delay=5, succeed=True)
 
-        **Task** - Sleep (delay) for the requested number of seconds.
+        **Task** (abortable) - Sleep (delay) for the requested number of
+        seconds.
 
         This can run simultaneously with the acq Process.  This Task
         should run in the reactor thread.

--- a/ocs/agents/host_manager/agent.py
+++ b/ocs/agents/host_manager/agent.py
@@ -507,7 +507,9 @@ class HostManager:
             yield dsleep(max(min(sleep_times), .001))
         return True, 'Exited.'
 
+    @inlineCallbacks
     def _stop_manager(self, session, params):
+        yield
         if session.status == 'done':
             return
         session.set_status('stopping')

--- a/ocs/agents/registry/agent.py
+++ b/ocs/agents/registry/agent.py
@@ -187,8 +187,10 @@ class Registry:
 
         return True, "Stopped registry main process"
 
+    @inlineCallbacks
     def _stop_main(self, session, params):
         """Stop function for the 'main' process."""
+        yield
         if self._run:
             session.set_status('stopping')
             self._run = False

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -383,7 +383,7 @@ class OCSAgent(ApplicationSession):
                launched in a worker thread, rather than running in the
                main reactor thread.
             aborter_blocking(bool or None): Indicates that ``aborter``
-               should be run in a worked thread, rather than running
+               should be run in a worker thread, rather than running
                in the main reactor thread.  Defaults to value of
                ``blocking``.
             startup (bool or dict): Controls if and how the Operation

--- a/tests/agents/test_fakedata.py
+++ b/tests/agents/test_fakedata.py
@@ -54,6 +54,15 @@ def test_fake_data_delay_task(agent):
     res = yield agent.delay_task(session, params=params)
     assert res[0] is True
 
+@pytest_twisted.inlineCallbacks
+def test_fake_data_delay_task_abort(agent):
+    session = create_session('delay_task')
+    params = {'delay': 0.001, 'succeed': True}
+    D1 = agent.delay_task(session, params=params)
+    D2 = yield agent._abort_delay_task(session, params=None)
+    res = yield D1
+    assert res[0] is False
+
 
 def test_fake_data_try_set_job_running_job(agent):
     # set running job to 'acq'

--- a/tests/agents/test_fakedata.py
+++ b/tests/agents/test_fakedata.py
@@ -30,18 +30,20 @@ def test_fake_data_acq(agent):
 
 
 class TestStopAcq:
+    @pytest_twisted.inlineCallbacks
     def test_fake_data_stop_acq_not_running(self, agent):
         session = create_session('acq')
-        res = agent._stop_acq(session, params=None)
+        res = yield agent._stop_acq(session, params=None)
         assert res[0] is False
 
+    @pytest_twisted.inlineCallbacks
     def test_fake_data_stop_acq_while_running(self, agent):
         session = create_session('acq')
 
         # set running job to 'acq'
         agent.job = 'acq'
 
-        res = agent._stop_acq(session, params=None)
+        res = yield agent._stop_acq(session, params=None)
         assert res[0] is True
 
 

--- a/tests/agents/test_registry_agent.py
+++ b/tests/agents/test_registry_agent.py
@@ -70,18 +70,20 @@ class TestMain:
 
 
 class TestStopMain:
+    @pytest_twisted.inlineCallbacks
     def test_registry_stop_main_while_running(self, agent):
         session = create_session('main')
 
         # Fake run main process
         agent._run = True
 
-        res = agent._stop_main(session, params=None)
+        res = yield agent._stop_main(session, params=None)
         assert res[0] is True
 
+    @pytest_twisted.inlineCallbacks
     def test_registry_stop_main_not_running(self, agent):
         session = create_session('main')
-        res = agent._stop_main(session, params=None)
+        res = yield agent._stop_main(session, params=None)
         assert res[0] is False
 
 


### PR DESCRIPTION
## Description

- Task abort is supported by OCSAgent.
- stopper / aborter functions run in same threading model as the start function (by default; can override).
- stopper / aborter wrapping code performs checks to avoid running the stopper / aborter if op is not in progress (solves #214).

## Motivation and Context

Task abort has always been a planned part of the API, with similar behavior to Process stop.  As we transition to more realistic and automated operation, long-running Tasks need to have smart abort capabilities (we can't just cycle the Agent whenever a Task needs to be interrupted).

Resolves #214.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I tested this using the FakeDataAgent and HostManager, through ocs-web.  I also confirmed the OCSClient interface passes abort requests successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

The potentially breaking change here is that stopper functions (for Processes) will now be run in the same threading pattern (reactor or worker thread) as the starter function, unless the user explicitly requests the other pattern when registering the Process.  Previously, the default was to always launch the stopper in a worker thread.

So the new default could affect any Process that is currently registered with blocking=False.  However (a) such Processes are rare and (b) there's a bit of code that will catch the case that a stopper function doesn't return a Deferred.
- W.r.t. (a), I've fixed up the stopper functions in OCS to be compatible with the new defaults.  In SOCS, the only cases seem to be the acu_agent (which is going to be modified in response to this work anyway) and the meinberg_m1000 (which looks like it will be handled properly by (b)).
- W.r.t. (b), if blocking=False, then the stopper function is invoked from the reactor.  If the function is decorated with inlineCallbacks, then this will return a Deferred.  So: if the function doesn't return a Deferred, it must have been implemented to run in a worker thread.  We just ran it in the reactor, which is not the same, but is probably ok since stopper functions usually just set update some instance variable so the Process knows to exit.  So, mission accomplished.  It's not exactly the same as running in the worker thread but is probably safe and leads to the same result.  (When this work-around is applied, a message is printed to the logs.)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
