### PR TITLE
Use pip installed so3g in GH Action workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,27 +24,19 @@ jobs:
     - name: Install ocs
       run: |
         pip3 install -r requirements.txt
-        pip3 install -e .
+        pip3 install -e .[so3g]
 
     # Test (already been run by pytest workflow, but they don't take long...)
     # Unit Tests
     - name: Run unit tests
       working-directory: ./tests
       run: |
-        COVERAGE_FILE=.coverage.unit python3 -m pytest --cov -m 'not (integtest or spt3g)'
-
-    - name: Build docker image for containerized tests
-      run: |
-        docker-compose build ocs
-
-    - name: Test with pytest within a docker container
-      run: |
-        docker run -v $PWD:/coverage --rm -w="/app/ocs/tests/" ocs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov -m 'spt3g'"
+        COVERAGE_FILE=.coverage.unit python3 -m pytest --cov -m 'not integtest'
 
     # Integration Tests
     - name: Build images for integration tests
       run: |
-        docker-compose build ocs-fake-data-agent ocs-aggregator-agent ocs-crossbar
+        docker-compose build ocs ocs-fake-data-agent ocs-aggregator-agent ocs-crossbar
 
     - name: Run integration tests
       working-directory: ./tests
@@ -135,7 +127,7 @@ jobs:
     - name: Run unit tests
       working-directory: ./tests
       run: |
-        python3 -m pytest -m 'not (integtest or spt3g)'
+        python3 -m pytest -m 'not integtest'
 
     - name: upload to PyPI
       run: |

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -24,27 +24,19 @@ jobs:
     - name: Install ocs
       run: |
         pip3 install -r requirements.txt
-        pip3 install -e .
+        pip3 install -e .[so3g]
 
     # Test (steps from pytest workflow)
     # Unit Tests
     - name: Run unit tests
       working-directory: ./tests
       run: |
-        COVERAGE_FILE=.coverage.unit python3 -m pytest --cov -m 'not (integtest or spt3g)'
-
-    - name: Build docker image for containerized tests
-      run: |
-        docker-compose build ocs
-
-    - name: Test with pytest within a docker container
-      run: |
-        docker run -v $PWD:/coverage --rm -w="/app/ocs/tests/" ocs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov -m 'spt3g'"
+        COVERAGE_FILE=.coverage.unit python3 -m pytest --cov -m 'not integtest'
 
     # Integration Tests
     - name: Build images for integration tests
       run: |
-        docker-compose build ocs-fake-data-agent ocs-aggregator-agent ocs-crossbar
+        docker-compose build ocs ocs-fake-data-agent ocs-aggregator-agent ocs-crossbar
 
     - name: Run integration tests
       working-directory: ./tests

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,26 +33,18 @@ jobs:
     - name: Install ocs
       run: |
         pip3 install -r requirements.txt
-        pip3 install -e .
+        pip3 install -e .[so3g]
 
     # Unit Tests
     - name: Run unit tests
       working-directory: ./tests
       run: |
-        COVERAGE_FILE=.coverage.unit python3 -m pytest --cov -m 'not (integtest or spt3g)'
-
-    - name: Build docker image for containerized tests
-      run: |
-        docker-compose build ocs
-
-    - name: Test with pytest within a docker container
-      run: |
-        docker run -v $PWD:/coverage --rm -w="/app/ocs/tests/" ocs sh -c "COVERAGE_FILE=/coverage/.coverage.docker python3 -m pytest --cov -m 'spt3g'"
+        COVERAGE_FILE=.coverage.unit python3 -m pytest --cov -m 'not integtest'
 
     # Integration Tests
     - name: Build images for integration tests
       run: |
-        docker-compose build ocs-fake-data-agent ocs-aggregator-agent ocs-crossbar
+        docker-compose build ocs ocs-fake-data-agent ocs-aggregator-agent ocs-crossbar
 
     - name: Run integration tests
       working-directory: ./tests

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,10 @@ Install and update with pip::
 
     $ pip3 install -U ocs
 
+If you need to install the optional so3g module you can do so via::
+
+    $ pip3 install -U ocs[so3g]
+
 Installing from Source
 ``````````````````````
 

--- a/ocs/agent/aggregator.py
+++ b/ocs/agent/aggregator.py
@@ -10,8 +10,8 @@ txaio.use_twisted()
 
 from ocs.ocs_feed import Block, Feed
 
-from spt3g import core
 import so3g
+from spt3g import core
 
 
 HKAGG_VERSION = 2

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -2,5 +2,4 @@ pytest
 pytest-cov
 docker
 pytest-docker-compose
-pytest-dependency
 pytest-twisted

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -3,3 +3,4 @@ pytest-cov
 docker
 pytest-docker-compose
 pytest-twisted
+so3g

--- a/setup.py
+++ b/setup.py
@@ -42,4 +42,7 @@ setup (name = 'ocs',
            'influxdb',
            'numpy',
        ],
+       extras_require={
+           "so3g": ["so3g"],
+       },
 )

--- a/tests/agents/test_aggregator_agent.py
+++ b/tests/agents/test_aggregator_agent.py
@@ -10,23 +10,18 @@ from agents.util import (
     generate_data_for_queue
 )
 
-try:
-    # depends on spt3g
-    from aggregator_agent import AggregatorAgent
+# depends on spt3g
+from aggregator_agent import AggregatorAgent
 
-    args = mock.MagicMock()
-    args.time_per_file = 3
-    args.data_dir = '/tmp/data'
-    # start idle so we can use a tmpdir for data_dir
-    args.initial_state = 'idle'
+args = mock.MagicMock()
+args.time_per_file = 3
+args.data_dir = '/tmp/data'
+# start idle so we can use a tmpdir for data_dir
+args.initial_state = 'idle'
 
-    agent = create_agent_fixture(AggregatorAgent, {'args': args})
-except ModuleNotFoundError as e:
-    print(f"Unable to import: {e}")
+agent = create_agent_fixture(AggregatorAgent, {'args': args})
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=['so3g'], scope='session')
 class TestRecord:
     def test_aggregator_agent_record_no_data(self, agent, tmpdir):
         # repoint data_dir to tmpdir fixture
@@ -62,8 +57,6 @@ class TestRecord:
         assert session.data['providers']['observatory.test-agent1.feeds.test_feed']['last_block_received'] == 'temps'
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=['so3g'], scope='session')
 def test_aggregator_agent_enqueue_data_no_aggregate(agent):
     agent.aggregate = False
 
@@ -73,8 +66,6 @@ def test_aggregator_agent_enqueue_data_no_aggregate(agent):
     assert agent.incoming_data.empty()
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=['so3g'], scope='session')
 class TestStopRecord:
     def test_aggregator_agent_stop_record_while_running(self, agent):
         session = create_session('record')

--- a/tests/integration/test_aggregator_agent_integration.py
+++ b/tests/integration/test_aggregator_agent_integration.py
@@ -21,7 +21,6 @@ run_agent = create_agent_runner_fixture(
 client = create_client_fixture('aggregator-local')
 
 
-@pytest.mark.dependency(depends=["so3g"], scope='session')
 @pytest.mark.integtest
 def test_aggregator_agent_record(wait_for_crossbar, run_agent, client):
     resp = client.record.start(test_mode=True)

--- a/tests/integration/test_crossbar_integration.py
+++ b/tests/integration/test_crossbar_integration.py
@@ -5,13 +5,9 @@ import pytest
 import docker
 
 from ocs.ocs_client import OCSClient
+from so3g import hk
 
 from integration.util import create_crossbar_fixture, restart_crossbar
-
-try:
-    from so3g import hk
-except ModuleNotFoundError as e:
-    print(f"Unable to import so3g: {e}")
 
 pytest_plugins = ("docker_compose",)
 
@@ -20,19 +16,6 @@ wait_for_crossbar = create_crossbar_fixture()
 
 
 CROSSBAR_SLEEP = 5  # time to wait before trying to make first connection
-
-
-@pytest.mark.spt3g
-@pytest.mark.dependency(name="so3g")
-def test_so3g_spt3g_import():
-    """Test that we can import so3g. Used to skip tests dependent on
-    this import.
-
-    """
-    import so3g
-
-    # Just to prevent flake8 from complaining
-    print(so3g.__file__)
 
 
 # @pytest.mark.integtest
@@ -76,7 +59,6 @@ def test_fake_data_after_crossbar_restart(wait_for_crossbar):
 #     """
 #     pass
 
-@pytest.mark.dependency(depends=["so3g"])
 @pytest.mark.integtest
 def test_aggregator_after_crossbar_restart(wait_for_crossbar):
     """Test that the aggregator reconnects after a crossbar restart and that

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 markers =
     integtest: marks tests as integration test (deselect with '-m "not integtest"')
-    spt3g: marks tests that depend on spt3g (deselect with '-m "not spt3g"')

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -4,32 +4,12 @@ import pytest
 
 from unittest.mock import patch
 
-try:
-    import so3g
-    from spt3g import core
+import so3g
+from spt3g import core
 
-    from ocs.agent.aggregator import Provider, g3_cast, make_filename
-except ModuleNotFoundError as e:
-    print(f"Unable to import either so3g or spt3g: {e}")
+from ocs.agent.aggregator import Provider, g3_cast, make_filename
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(name="so3g")
-def test_so3g_spt3g_import():
-    """Test that we can import spt3g/so3g. Used to skip tests dependent on
-    these imports.
-
-    """
-    import so3g
-    from spt3g import core
-
-    # Just to avoid flake8 complaining we aren't using these imports
-    print(so3g.__file__)
-    print(core.__file__)
-
-
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_passing_float_in_provider_to_frame():
     """Float is the expected type we should be passing.
 
@@ -53,8 +33,6 @@ def test_passing_float_in_provider_to_frame():
     provider.to_frame(hksess=sess)
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_passing_float_like_str_in_provider_to_frame():
     """Here we test passing a string amongst ints. This shouldn't make it to
     the aggregator, and instead the Aggregator logs should display an error
@@ -80,8 +58,6 @@ def test_passing_float_like_str_in_provider_to_frame():
     provider.to_frame(hksess=sess)
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_passing_non_float_like_str_in_provider_to_frame():
     """Similar to passing a float like str, here we test passing a non-float
     like str. We can't put this into an so3g.IrregBlockDouble(), so this'll fail.
@@ -108,8 +84,6 @@ def test_passing_non_float_like_str_in_provider_to_frame():
     provider.to_frame(hksess=sess)
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_sparsely_sampled_block():
     """If a block is sparsely sampled and published, the aggregator was
     including its block_name anyway, even when missing. This test publishes two
@@ -183,8 +157,6 @@ def test_sparsely_sampled_block():
 
 # This is perhaps another problem, I'm passing irregular length data sets and
 # it's not raising any sort of alarm. How does this get handled?
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_data_type_in_provider_save_to_block():
     provider = Provider('test_provider', 'test_sessid', 3, 1)
     provider.frame_start_time = time.time()
@@ -198,8 +170,6 @@ def test_data_type_in_provider_save_to_block():
 
 
 # 'data' field names
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_passing_invalid_data_field_name1():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -223,8 +193,6 @@ def test_passing_invalid_data_field_name1():
     assert 'invalid.key' not in provider.blocks['test'].data.keys()
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_passing_invalid_data_field_name2():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -248,8 +216,6 @@ def test_passing_invalid_data_field_name2():
     assert '__123invalid.key' not in provider.blocks['test'].data.keys()
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_passing_too_long_data_field_name():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -274,8 +240,6 @@ def test_passing_too_long_data_field_name():
     assert 'a'*255 in provider.blocks['test'].data.keys()
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_long_duplicate_name():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -301,8 +265,6 @@ def test_long_duplicate_name():
     assert 'a'*252 + '_01' in provider.blocks['test'].data.keys()
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_reducing_to_duplicate_field_names():
     """Invalid data field names get modified by the Aggregator to comply with
     the set rules. This can result in duplicate field names under certain
@@ -331,8 +293,6 @@ def test_reducing_to_duplicate_field_names():
     assert 'aninvalidkey_01' in provider.blocks['test'].data.keys()
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_space_replacement_in_field_names():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -355,8 +315,6 @@ def test_space_replacement_in_field_names():
     assert 'key2' in provider.blocks['test'].data.keys()
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_empty_field_name():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -378,8 +336,6 @@ def test_empty_field_name():
     assert '' not in provider.blocks['test'].data.keys()
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_enforced_field_which_becomes_empty():
     """Invalid data field names should get caught by the Feed, however, we
     check for them in the Aggregator as well.
@@ -403,8 +359,6 @@ def test_enforced_field_which_becomes_empty():
     assert 'invalid_field_123' in provider.blocks['test'].data.keys()
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_g3_cast():
     correct_tests = [
         ([1, 2, 3, 4], core.G3VectorInt),
@@ -427,8 +381,6 @@ def test_g3_cast():
             g3_cast(x)
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_make_filename_directory_creation(tmpdir):
     """make_filename() should be able to create directories to store the .g3
     files in.
@@ -440,8 +392,6 @@ def test_make_filename_directory_creation(tmpdir):
     os.path.isdir(os.path.basename(fname))
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 def test_make_filename_directory_creation_no_subdirs(tmpdir):
     """make_filename() should raise a FileNotFoundError if make_subdirs is
     False.
@@ -452,8 +402,6 @@ def test_make_filename_directory_creation_no_subdirs(tmpdir):
         make_filename(test_dir, make_subdirs=False)
 
 
-@pytest.mark.spt3g
-@pytest.mark.dependency(depends=["so3g"])
 @patch('os.makedirs', side_effect=PermissionError('mocked permission error'))
 def test_make_filename_directory_creation_permissions(tmpdir):
     """make_filename() should raise a PermissionError if it runs into one when


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Now that so3g is easily pip installable this allows us to do several things:
- Install so3g within the GH Actions workflows directly, meaning we can drop the use of docker containers for running tests that depend on spt3g/so3g.
- Remove the spt3g marker on our tests used to select only those test which do or do not depend on spt3g/so3g. We now just insist that so3g is installed for testing by adding it to the `requirements/testing.txt` file. Associated with this we no longer check for successful imports as a dependency for running those tests, meaning we can also drop the `pytest-dependency` module as a requirement.

I've also listed so3g as an optional requirement via `extras_install` in `setup.py`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Take advantage of the fact that so3g is now on PyPI and easily installable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've tested the test locally, and they will run in this PR/have run on these commits. The deploy develop and deploy workflow changes are currently untested, though mimic those changes made in the pytest workflow.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
