### PR TITLE
Passes environment variables to docker subprocesses

### DIFF
--- a/ocs/agent/host_manager.py
+++ b/ocs/agent/host_manager.py
@@ -272,7 +272,7 @@ def _run_docker_compose(args, docker_compose_bin=None):
     if docker_compose_bin is None:
         docker_compose_bin = shutil.which('docker-compose')
     return utils.getProcessOutputAndValue(
-        docker_compose_bin, args)
+        docker_compose_bin, args, env=os.environ)
 
 
 class DockerContainerHelper:
@@ -370,7 +370,7 @@ def parse_docker_state(docker_compose_file, docker_compose_bin=None):
     # Run docker inspect.
     for cont_id in cont_ids:
         out, err, code = yield utils.getProcessOutputAndValue(
-            'docker', ['inspect', cont_id])
+            'docker', ['inspect', cont_id], env=os.environ)
         if code != 0 and 'No such object' in err.decode('utf8'):
             # This is likely due to a race condition where some
             # container was brought down since we ran docker-compose.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Small change to the host-manager agent so that it passes the environment through to subprocess calls. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is required for calling docker services that use environment variables.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested by running the host_manager at Penn
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
