### PR TITLE
Add boolean support to feeds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # A container setup with an installation of ocs.
 
 # Use ubuntu base image
-FROM simonsobs/so3g:v0.1.0-117-g75c1d8d
+FROM simonsobs/so3g:v0.1.3-13-g5471f0d
 
 # Set locale
 ENV LANG C.UTF-8

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -248,17 +248,15 @@ class Feed:
         supported types.
 
         Args:
-            value (list, float, int):
+            value (list, float, int, bool):
                 'data' dictionary value published (see Feed.publish_message for details).
 
         """
-        valid_types = (float, int, str)
+        valid_types = (float, int, str, bool)
 
-        # separate bool checks since bool is a subclass of int
         # multi-sample check
         if isinstance(value, list):
-            if (any(isinstance(x, bool) for x in value)
-                    or not all(isinstance(x, valid_types) for x in value)):
+            if not all(isinstance(x, valid_types) for x in value):
                 type_set = set([type(x) for x in value])
                 invalid_types = type_set.difference(valid_types)
                 raise TypeError("message 'data' block contains invalid data" +
@@ -266,7 +264,7 @@ class Feed:
 
         # single sample check
         else:
-            if isinstance(value, bool) or not isinstance(value, valid_types):
+            if not isinstance(value, valid_types):
                 invalid_type = type(value)
                 raise TypeError("message 'data' block contains invalid " +
                                 f"data type: {invalid_type}")

--- a/tests/test_ocs_feed.py
+++ b/tests/test_ocs_feed.py
@@ -92,6 +92,22 @@ class TestPublishMessage:
 
         test_feed.publish_message(test_message)
 
+    def test_invalid_single_sample_input(self):
+        mock_agent = MagicMock()
+        test_feed = ocs_feed.Feed(mock_agent, 'test_feed', record=True)
+
+        test_message = {
+            'block_name': 'test',
+            'timestamps': time.time(),
+            'data': {
+                'key1': 1.,
+                'key2': None,
+            }
+        }
+
+        with pytest.raises(TypeError):
+            test_feed.publish_message(test_message)
+
     def test_str_multi_sample_input(self):
         """Passing multiple points, including invalid datatypes,
         should cause a TypeError upon publishing.

--- a/tests/test_ocs_feed.py
+++ b/tests/test_ocs_feed.py
@@ -76,8 +76,7 @@ class TestPublishMessage:
             }
         }
 
-        with pytest.raises(TypeError):
-            test_feed.publish_message(test_message)
+        test_feed.publish_message(test_message)
 
     def test_bool_multi_sample_input(self):
         mock_agent = MagicMock()
@@ -91,8 +90,7 @@ class TestPublishMessage:
             }
         }
 
-        with pytest.raises(TypeError):
-            test_feed.publish_message(test_message)
+        test_feed.publish_message(test_message)
 
     def test_str_multi_sample_input(self):
         """Passing multiple points, including invalid datatypes,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Following the addition of G3VectorBool to so3g in https://github.com/simonsobs/so3g/pull/118, this adds support for booleans to OCS feeds.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Boolean support was requested following https://github.com/simonsobs/socs/pull/238. 

Resolves #259.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Just ran the unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
