### PR TITLE
Fix flaky registry test

### DIFF
--- a/tests/integration/test_registry_agent_integration.py
+++ b/tests/integration/test_registry_agent_integration.py
@@ -31,5 +31,6 @@ def test_registry_agent_main(wait_for_crossbar, run_agent, client):
     assert resp.session['op_code'] == OpCode.RUNNING.value
 
     client.main.stop()
+    client.main.wait()  # wait for process to exit
     resp = client.main.status()
-    assert resp.session['op_code'] == OpCode.STOPPING.value
+    assert resp.session['op_code'] == OpCode.SUCCEEDED.value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a flaky registry test.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This registry test would occasionally fail, as it was relying on catching the state of the main registry process in `STOPPING` to pass. The failure was that sometimes it'd still be `RUNNING`. The fix is to just wait for the process to end and check that it `SUCCEEDED`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally by running the test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
