### PR TITLE
HostManager supports new plugin system

### DIFF
--- a/ocs/agent_cli.py
+++ b/ocs/agent_cli.py
@@ -83,3 +83,10 @@ def main(args=None):
     # Expose the imported function by having locals=globals()
     exec(import_line, globals(), globals())
     start()  # noqa: F821
+
+
+if __name__ == '__main__':
+    # This __main__ checker allows ocs-agent-cli to be invoked through
+    # python -m ocs.agent_cli; this is helpful with, e.g., conda when
+    # one is trying to use a particular interpreter and its packages.
+    main()

--- a/ocs/agents/host_manager/agent.py
+++ b/ocs/agents/host_manager/agent.py
@@ -300,11 +300,12 @@ class HostManager:
             prot = self._get_docker_helper(instance)
         else:
             iid = instance['instance_id']
+            pyth = sys.executable
             script = instance['agent_script']
             if script == '__plugin__':
-                cmd = ['ocs-agent-cli']
+                cmd = [pyth, '-m', 'ocs.agent_cli']
             else:
-                cmd = [sys.executable, script]
+                cmd = [pyth, script]
             cmd.extend([
                 '--instance-id', iid,
                 '--site-file', self.site_config_file,

--- a/ocs/ocs_systemd.py
+++ b/ocs/ocs_systemd.py
@@ -44,8 +44,7 @@ PYTHON={python_bin}
 
 ###
 
-${{PYTHON}} \\
-  {host_manager_agent} \\
+${{PYTHON}} -m ocs.agent_cli \\
   --site-file=${{SITE_FILE}} \\
   {host_manager_args}
 """
@@ -73,8 +72,6 @@ def get_parser():
                        "Override the name of the systemd service.")
     group.add_argument('--service-host', help=
                        "Set a hostname to use when generating the service name.")
-    group.add_argument('--host-manager-agent', help=
-                       "Override the host_manager.py agent script.")
     return parser
 
 def main(args=None):
@@ -127,14 +124,6 @@ def main(args=None):
         args.python_bin = sys.executable
     if args.site_file is None:
         args.site_file = site.source_file
-
-    if args.host_manager_agent is None:
-        # Determine path to host_manager agent.
-        for p in host.agent_paths:
-            if not p in sys.path:
-                sys.path.append(p)
-        site_config.scan_for_agents()
-        args.host_manager_agent = site_config.agent_script_reg['HostManager']
 
     host_manager_args = [
         f'--instance-id={args.instance_id}',


### PR DESCRIPTION
Note it still supports the old system, too.

I think it will be possible to limp along with both systems for a bit, which might ease transition.

Note I also enabled `python -m ocs.agent_cli`, which is a useful way to run it on a conda system without actually entering the conda env.