### PR TITLE
docs: Fix path to ocs_plugin_standard.py in agent guide

### DIFF
--- a/docs/developer/writing_an_agent/next.rst
+++ b/docs/developer/writing_an_agent/next.rst
@@ -32,7 +32,7 @@ each one of which should contain an ``ocs_plugin_<experiment>.py`` file. This
 script registers all of the agents so that Host Manager can start and stop
 them. An example (of the standard ocs library plugin file) is shown here:
 
-.. include:: ../../../agents/ocs_plugin_standard.py
+.. include:: ../../../ocs/agents/ocs_plugin_standard.py
     :code: python
 
 Development Tips


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a broken path that was missed in #284.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Working on documentation recently I noticed this error:
```
/home/koopman/git/ocs/docs/developer/writing_an_agent/next.rst:35: CRITICAL: Problems with "include" directive path:
InputError: [Errno 2] No such file or directory: '../agents/ocs_plugin_standard.py'.
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested the build locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
