### PR TITLE
Adds wait-time arg to registry

### DIFF
--- a/docs/agents/registry.rst
+++ b/docs/agents/registry.rst
@@ -10,6 +10,11 @@ The Registry Agent tracks all currently running Agents on the OCS network,
 providing the ability to monitor the status of each Agent's Tasks and Processes
 through the :ref:`operation_monitor`.
 
+.. argparse::
+   :module: ocs.agents.registry.agent
+   :func: make_parser
+   :prog: agent.py
+
 Configuration File Examples
 ----------------------------
 
@@ -23,7 +28,9 @@ An example site-config-file block::
 
     { 'agent-class': 'RegistryAgent',
       'instance-id': 'registry',
-      'arguments': []},
+      'arguments': [
+        ['--wait-time', 30]
+      ]},
 
 Docker Compose
 ``````````````

--- a/ocs/agents/registry/agent.py
+++ b/ocs/agents/registry/agent.py
@@ -127,7 +127,7 @@ class Registry:
         msg = {'block_name': addr,
                'timestamp': time.time(),
                'data': {}}
-        self.log.info(addr)
+        self.log.debug(addr)
         for op_name, op_code in reg_agent.op_codes.items():
             field = f'{addr}_{op_name}'
             field = field.replace('.', '_')

--- a/ocs/agents/registry/agent.py
+++ b/ocs/agents/registry/agent.py
@@ -115,7 +115,7 @@ class Registry:
         addr = feed['agent_address']
         if addr not in self.registered_agents:
             self.registered_agents[addr] = RegisteredAgent(feed)
-        
+
         reg_agent = self.registered_agents[addr]
         publish = op_codes != reg_agent.op_codes
         self.registered_agents[addr].refresh(op_codes=op_codes)
@@ -141,7 +141,6 @@ class Registry:
             msg['data'][field] = op_code
         if msg['data']:
             self.agent.publish_to_feed('agent_operations', msg)
-
 
     @ocs_agent.param('test_mode', default=False, type=bool)
     @inlineCallbacks

--- a/tests/agents/test_registry_agent.py
+++ b/tests/agents/test_registry_agent.py
@@ -3,9 +3,11 @@ import pytest_twisted
 
 from agents.util import create_session, create_agent_fixture
 
-from ocs.agents.registry.agent import Registry
+from ocs.agents.registry.agent import Registry, make_parser
 
-agent = create_agent_fixture(Registry)
+parser = make_parser()
+args = parser.parse_args(['--wait-time', '0.1'])
+agent = create_agent_fixture(Registry, agent_kwargs=dict(args=args))
 
 
 class TestMain:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Increases default wait time of registry and adds corresponding command line arg.

## Description
Using Matthews script to scan hk files I noticed that the registry was taking up a significant amount of disk space on the SAT1, since the number of fields increases with the number of other agents running on the system. This PR reduces the sleep time in the main loop from 1 sec to 30 sec to mitigate this, and adds the `wait-time` argument that allows users to set it in the sys-config.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Disk space / grafana issues

## How Has This Been Tested?
Tested on my local desktop to make sure it runs.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
