### PR TITLE
Update ocs-local-support so it can launch HostManager again

### DIFF
--- a/ocs/ocsbow.py
+++ b/ocs/ocsbow.py
@@ -577,7 +577,7 @@ class HostManagerManager:
                 return True, 'Agent has exited and relinquished registrations.'
         return False, 'Agent did not die within %.1f seconds.' % timeout
 
-    def start(self, check=True, timeout=5., up=False, foreground=False):
+    def start(self, check=True, timeout=5., up=None, foreground=False):
         if self.instance_id is None:
             print('\nERROR: cannot "start" HostManager because '
                   'instance_id could not be determined.')
@@ -602,8 +602,10 @@ class HostManagerManager:
                '--site-file', self.site_config.site.source_file,
                '--site-host', host.name,
                '--working-dir', self.working_dir]
-        if up:
+        if up is True:
             cmd.extend(['--initial-state', 'up'])
+        if up is False:
+            cmd.extend(['--initial-state', 'down'])
         if not foreground:
             cmd.extend(['--quiet'])
 
@@ -960,7 +962,7 @@ def main_local(args=None):
             if any([soln == 'agent' for soln, text in supports.analysis]):
                 print('Trying to launch hostmanager agent...')
                 hm = supports.host_manager['ctrl']
-                ok, message = hm.start(up=True, foreground=args.foreground)
+                ok, message = hm.start(foreground=args.foreground)
                 if not ok:
                     raise OcsbowError('Failed to start manager process: %s' % message)
                 supports.update()  # refresh .analysis

--- a/ocs/ocsbow.py
+++ b/ocs/ocsbow.py
@@ -537,7 +537,7 @@ class HostManagerManager:
                     result['message'] = (
                         'Manager Process has been running for %i seconds.' %
                         (time.time() - session['start_time']))
-                    result['child_states'] = session['data']['child_states']
+                    result['child_states'] = session['data'].get('child_states', [])
                 else:
                     result['message'] = 'Manager Process is in state: %s' % status_text
             else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
ocs-local-support needs to be able to launch the HostManager, but that bit of code wasn't set up to use the new agent plugin.

## Description

If a user runs "ocs-local-support start agent", the HostManager is launched in the background using python -m ocs.agents.host_manager.agent.  This is used instead of -m ocs-agent-cli, because additional command line args need to be passed through at run time.

## Motivation and Context

Resolves #295

This use case was missed in the recent upgrade to plugin system.  The recommended alternative to "ocs-local-support start agent" is to use systemd, and that was tested.

## How Has This Been Tested?

Tested on a local config that was also used to test other HostManager/plugin updates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
