### PR TITLE
Add boolean support to Aggregator

### DIFF
--- a/ocs/agents/aggregator/drivers.py
+++ b/ocs/agents/aggregator/drivers.py
@@ -15,10 +15,16 @@ from spt3g import core
 
 HKAGG_VERSION = 2
 _g3_casts = {
-    str: core.G3String, int: core.G3Int, float: core.G3Double,
+    str: core.G3String,
+    int: core.G3Int,
+    float: core.G3Double,
+    bool: core.G3Bool,
 }
 _g3_list_casts = {
-    str: core.G3VectorString, int: core.G3VectorInt, float: core.G3VectorDouble,
+    str: core.G3VectorString,
+    int: core.G3VectorInt,
+    float: core.G3VectorDouble,
+    bool: core.G3VectorBool,
 }
 
 LOG = txaio.make_logger()
@@ -30,6 +36,7 @@ def g3_cast(data, time=False):
         int   -> G3Int
         str   -> G3String
         float -> G3Double
+        bool  -> G3Bool
 
     and lists of type X will go to G3VectorX. If ``time`` is set to True, will
     convert to G3Time or G3VectorTime with the assumption that ``data`` consists

--- a/ocs/agents/aggregator/drivers.py
+++ b/ocs/agents/aggregator/drivers.py
@@ -61,7 +61,7 @@ def g3_cast(data, time=False):
     else:
         dtype = type(data)
     if dtype not in _g3_casts.keys():
-        raise TypeError("g3_cast does not support type {}. Type must"
+        raise TypeError("g3_cast does not support type {}. Type must "
                         "be one of {}".format(dtype, _g3_casts.keys()))
     if is_list:
         if time:

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -364,8 +364,10 @@ def test_g3_cast():
         ([1, 2, 3, 4], core.G3VectorInt),
         ([1., 2., 3.], core.G3VectorDouble),
         (["a", "b", "c"], core.G3VectorString),
+        ([True, False], core.G3VectorBool),
         (3, core.G3Int),
-        ("test", core.G3String)
+        ("test", core.G3String),
+        (True, core.G3Bool),
     ]
     for x, t in correct_tests:
         assert isinstance(g3_cast(x), t)
@@ -374,7 +376,7 @@ def test_g3_cast():
     assert isinstance(g3_cast([1, 2, 3], time=True), core.G3VectorTime)
 
     incorrect_tests = [
-        ['a', 'b', 1, 2], True, [1, 1.0, 2]
+        ['a', 'b', 1, 2], [1, 1.0, 2]
     ]
     for x in incorrect_tests:
         with pytest.raises(TypeError):

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -33,6 +33,26 @@ def test_passing_float_in_provider_to_frame():
     provider.to_frame(hksess=sess)
 
 
+def test_passing_bool_in_provider_to_frame():
+    # Dummy Provider for testing
+    provider = Provider('test_provider', 'test_sessid', 3, 1)
+    provider.frame_start_time = time.time()
+    data = {'test': {'block_name': 'test',
+                     'timestamps': [time.time()],
+                     'data': {'key1': [True],
+                              'key2': [False]},
+                     }
+            }
+    provider.save_to_block(data)
+
+    # Dummy HKSessionHelper
+    sess = so3g.hk.HKSessionHelper(description="testing")
+    sess.start_time = time.time()
+    sess.session_id = 'test_sessid'
+
+    provider.to_frame(hksess=sess)
+
+
 def test_passing_float_like_str_in_provider_to_frame():
     """Here we test passing a string amongst ints. This shouldn't make it to
     the aggregator, and instead the Aggregator logs should display an error

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -376,7 +376,7 @@ def test_g3_cast():
     assert isinstance(g3_cast([1, 2, 3], time=True), core.G3VectorTime)
 
     incorrect_tests = [
-        ['a', 'b', 1, 2], [1, 1.0, 2]
+        ['a', 'b', 1, 2], [1, 1.0, 2], {'foo': 'bar'}
     ]
     for x in incorrect_tests:
         with pytest.raises(TypeError):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds boolean support to the Aggregator Agent. This was missed when adding Bool support to OCS Feeds in #269.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed in the aggregator logs on the UCSD system.

```
2022-11-04T17:10:27+0000 Error received when casting timestream! g3_cast does not support type <class 'bool'>. Type mustbe one of dict_keys([<class 'str'>, <class 'int'>, <class 'float'>])
2022-11-04T17:10:47+0000 Error received when casting timestream! g3_cast does not support type <class 'bool'>. Type mustbe one of dict_keys([<class 'str'>, <class 'int'>, <class 'float'>])
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tests updated with G3Bool and G3VectorBool examples.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
