### PR TITLE
Combine payloads before writing to influxdb

### DIFF
--- a/docs/agents/influxdb_publisher.rst
+++ b/docs/agents/influxdb_publisher.rst
@@ -61,6 +61,8 @@ online at all times. An example compose file would look like::
       restart: always
       ports:
         - "8086:8086"
+      environment:
+        - INFLUXDB_HTTP_LOG_ENABLED=false
       volumes:
         - /srv/influxdb:/var/lib/influxdb
 

--- a/docs/user/docker_config.rst
+++ b/docs/user/docker_config.rst
@@ -48,6 +48,8 @@ components)::
         restart: always
         ports:
           - "8086:8086"
+        environment:
+          - INFLUXDB_HTTP_LOG_ENABLED=false
         volumes:
           - /srv/influxdb:/var/lib/influxdb
 
@@ -220,6 +222,8 @@ Where the separate compose files would look something like::
         restart: always
         ports:
           - "8086:8086"
+        environment:
+          - INFLUXDB_HTTP_LOG_ENABLED=false
         volumes:
           - /srv/influxdb:/var/lib/influxdb
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -119,6 +119,8 @@ replaced with the hostname of your computer.
         restart: always
         ports:
           - "8086:8086"
+        environment:
+          - INFLUXDB_HTTP_LOG_ENABLED=false
         volumes:
           - influxdb-storage:/var/lib/influxdb
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR combines the data in the queue before writing to the InfluxDB. 

Currently, the InfluxDB Publisher will issue separate `write_points()` calls for each item in the queue (data published on a feed). This results in increasingly more `write_points()` calls depending on how many feeds are being published to on the OCS network. `write_points()` is efficient on large payloads (we had previously set a "batch size" of 10,000 points). I don't think we'll be approaching this limit, but write now each payload is generally pretty small. 

This should improve write efficiency to the database a bit, though I'm not sure exactly how much.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was revisiting some of the structure of the publisher after recent reports of data lag in InfluxDB on several lab systems, most notably at UCSD.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally with 5 fake data agents writing to InfluxDB.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
