### PR TITLE
Remove 10 second fresh_time on registry feed

### DIFF
--- a/ocs/agents/registry/agent.py
+++ b/ocs/agents/registry/agent.py
@@ -101,7 +101,6 @@ class Registry:
 
         agg_params = {
             'frame_length': 60,
-            'fresh_time': 10,
         }
         self.agent.register_feed('agent_operations', record=True,
                                  agg_params=agg_params, buffer_time=0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Title says it all.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After #296 we are seeing the registry provider go stale every 30 seconds in the aggregator logs:
```
2022-11-10T16:43:08+0000 Provider observatory.registry.feeds.agent_operations went stale
2022-11-10T16:43:08+0000 Removing provider observatory.registry.feeds.agent_operations
2022-11-10T16:43:58+0000 Adding provider observatory.registry.feeds.agent_operations
2022-11-10T16:44:16+0000 Provider observatory.registry.feeds.agent_operations went stale
2022-11-10T16:44:16+0000 Removing provider observatory.registry.feeds.agent_operations
2022-11-10T16:44:58+0000 Adding provider observatory.registry.feeds.agent_operations
2022-11-10T16:45:08+0000 Provider observatory.registry.feeds.agent_operations went stale
2022-11-10T16:45:08+0000 Removing provider observatory.registry.feeds.agent_operations
2022-11-10T16:45:59+0000 Adding provider observatory.registry.feeds.agent_operations
2022-11-10T16:46:09+0000 Provider observatory.registry.feeds.agent_operations went stale
2022-11-10T16:46:09+0000 Removing provider observatory.registry.feeds.agent_operations
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested a local build on the UCSD system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
