### PR TITLE
Sanitize session data

### DIFF
--- a/docs/developer/session-data.rst
+++ b/docs/developer/session-data.rst
@@ -147,6 +147,9 @@ This block formats the latest values for each "channel" into a dictionary and
 stores it in ``session.data``.
 
 
+Structure and Content
+---------------------
+
 The structure of the ``data`` entry is not strictly defined, but
 please observe the following guidelines:
 
@@ -169,6 +172,30 @@ please observe the following guidelines:
     data structure may cause existing clients that make use of the ``session.data``
     object to break. Changes that do take place should be announced in the
     change logs of new OCS versions.
+
+
+There are some restrictions on what data can be carried in
+``session.data``:
+
+- The session.data will ultimately be converted and transported using
+  JSON, so some containers will be automatically converted into
+  JSON-compatible forms.  Specifically note that:
+
+  - dict keys must be strings.
+  - there is no distinction between lists and tuples.
+  - there is no (standardized) support for non-finite floats such as
+    inf, -inf, or NaN.
+
+- If your session.data contains any NaN, they will be converted to
+  None (which is transported as JSON null).
+- If your session.data contains inf/-inf, or other JSON-encodable
+  entities, OCS will raise an error.  To have those transported as
+  None/null, you should convert inf/-inf to NaN before storing the
+  data in session.data.
+- If your session.data includes numpy arrays (or scalars), these will
+  be converted to serializable types automatically using
+  ``numpy.tolist``.
+
 
 Client Access
 -------------

--- a/docs/developer/session-data.rst
+++ b/docs/developer/session-data.rst
@@ -181,7 +181,7 @@ There are some restrictions on what data can be carried in
   JSON, so some containers will be automatically converted into
   JSON-compatible forms.  Specifically note that:
 
-  - dict keys must be strings.
+  - dict keys will be converted to strings.
   - there is no distinction between lists and tuples.
   - there is no (standardized) support for non-finite floats such as
     inf, -inf, or NaN.

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -1104,11 +1104,14 @@ class OpSession:
                 return json_safe(data.tolist())
             if isinstance(data, (str, int, bool)):
                 return data
-            if math.isnan(data):
-                return None
-            if not math.isfinite(data):
-                raise ValueError('Session.data cannot store inf/-inf; '
-                                 'please convert to NaN.')
+            if isinstance(data, float):
+                if math.isnan(data):
+                    return None
+                if not math.isfinite(data):
+                    raise ValueError('Session.data cannot store inf/-inf; '
+                                     'please convert to NaN.')
+            # This could still be something weird but json.dumps will
+            # probably reject it!
             return data
 
         return {'session_id': self.session_id,

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -17,6 +17,8 @@ from autobahn.wamp.exception import ApplicationError, TransportLost
 from autobahn.exception import Disconnected
 from .ocs_twisted import in_reactor_context
 
+import json
+import math
 import time
 import datetime
 import socket
@@ -1055,7 +1057,9 @@ class OpSession:
         data : dict
           This is an area for the Operation code to store custom
           information for Control Clients to consume.  See notes
-          below.
+          below.  This structure will be tested for strict JSON
+          compliance, and certain translations performed (such as
+          converting NaN to None/null).
         messages : list
           A buffer of messages posted by the Operation.  Each element
           of the list is a tuple, (timestamp, message) where timestamp
@@ -1073,6 +1077,40 @@ class OpSession:
         advice on structuring your Agent session data.
 
         """
+        def json_safe(data, check_ok=False):
+            """Convert data so it can be serialized and decoded on
+            the other end.  This includes:
+
+            - Converting numpy arrays and scalars to generic lists and
+              Python basic types.
+
+            - Converting NaN to None (although crossbar handles
+              NaN/inf, web browsers may fail to deserialize the
+              invalid JSON this requires).
+
+            In the case of inf/-inf, a ValueError is raised.
+
+            """
+            if check_ok:
+                output = json_safe(data)
+                json.dumps(output, allow_nan=False)
+                return output
+            if isinstance(data, dict):
+                return {k: json_safe(v) for k, v in data.items()}
+            if isinstance(data, (list, tuple)):
+                return [json_safe(x) for x in data]
+            if hasattr(data, 'dtype'):
+                # numpy arrays and scalars.
+                return json_safe(data.tolist())
+            if isinstance(data, (str, int, bool)):
+                return data
+            if math.isnan(data):
+                return None
+            if not math.isfinite(data):
+                raise ValueError('Session.data cannot store inf/-inf; '
+                                 'please convert to NaN.')
+            return data
+
         return {'session_id': self.session_id,
                 'op_name': self.op_name,
                 'op_code': self.op_code.value,
@@ -1080,7 +1118,7 @@ class OpSession:
                 'success': self.success,
                 'start_time': self.start_time,
                 'end_time': self.end_time,
-                'data': self.data,
+                'data': json_safe(self.data, True),
                 'messages': self.messages}
 
     @property

--- a/tests/test_ocs_agent.py
+++ b/tests/test_ocs_agent.py
@@ -462,6 +462,7 @@ def test_session_data_good(mock_agent):
         'g': (np.array([1., 2., math.nan]),
               [1., 2., None]),
     }
+
     def test_task_good(session, args):
         # Populate session.data and exit.
         session.data = {

--- a/tests/test_ocs_agent.py
+++ b/tests/test_ocs_agent.py
@@ -457,7 +457,8 @@ def test_status_no_session(mock_agent):
                                                 ('d', [1., 2., math.nan], [1., 2., None]),
                                                 ('e', np.int64(10), 10),
                                                 ('f', np.array([10, 20, 30]), [10, 20, 30]),
-                                                ('g', np.array([1., 2., math.nan]), [1., 2., None])])
+                                                ('g', np.array([1., 2., math.nan]), [1., 2., None]),
+                                                ('h', {'x': math.nan}, {'x': None})])
 def test_session_data_good(key, value, expected):
     """Test that session.data is encoded as expected and can be
     JSON-serialized.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves #300 

## Description

- It's now ok to include numpy arrays / scalars in session.data -- they will be translated to simple lists of python scalars
- It's now ok to include NaN in session.data, it will be converted to None.
- It's now explicitly not ok to include +/- inf in session.data, an internal error will result.
- There are tests for the above.
- The expectations and behavior are documented.

This is a slight "break" in interface in that Inf/-Inf are now expressly forbidden, and NaN will render differently in clients that used to accept it (i.e. Python clients).  As discussed in the issue, this is deemed acceptable.

## How Has This Been Tested?

With tests.  Also with agent emulator in ocs-web.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Unless I am preparing a release, I have opened this PR onto the `develop` branch.
