### PR TITLE
Replace master and develop branches with "main" branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,4 +24,3 @@
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
-- [ ] Unless I am preparing a release, I have opened this PR onto the `develop` branch.

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,8 +1,8 @@
-name: Build Develop Images
+name: Build Test Images
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ main ]
     paths-ignore:
       - 'docs/**'
       - '**.rst'
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/pytest.yml
 
   build:
-    name: build and deploy dev images
+    name: build and deploy test images
     needs: test
     runs-on: ubuntu-latest
 
@@ -37,11 +37,11 @@ jobs:
         username: ${{ secrets.REGISTRY_USER }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
 
-    - name: Build and push development docker image
+    - name: Build and push test docker images
       env:
         DOCKERHUB_ORG: "simonsobs"
       run: |
-        export DOCKER_TAG=`git describe --tags --always`-dev
+        export DOCKER_TAG=`git describe --tags --always`
         echo "${DOCKER_TAG}"
 
         # Tag all images for upload to the registry

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,6 +5,23 @@ Contributing to OCS
 Branches
 --------
 
+Following release v0.10.1, ocs now has a single ``main`` branch, which replaces
+the old ``master`` and ``develop`` branch model, described below. ``main``
+functions like ``develop`` used to, and is the new default branch. Feature
+branches should be based off of the latest ``main``, and pull requests should
+be made into ``main``.
+
+Users that want a "stable" installation of ocs should install from PyPI and/or
+use tagged Docker images corresponding to the targeted release, i.e. v0.10.1.
+Installing from source (i.e. from the ``main`` branch) comes with the usual
+caveats of potential instability.
+
+Old Branching Model
+```````````````````
+
+    **Note:** This branching model is no longer used, but the description is
+    left here while we transition to the new one.
+
 There are two long-lived branches in OCS, ``master`` and ``develop``.
 ``master`` should be considered stable, and will only move forward on official
 releases. ``develop`` may be unstable, and is where all development should take
@@ -17,9 +34,15 @@ branches off of the latest ``develop`` branch, and pull request them into
 Pull Requests
 -------------
 
-When opening a pull request, you should push your feature branch, and select
-the ``develop`` branch as the base branch, the branch you want to merge your
-feature branch into.
+If you are an SO collaborator you may have push access, in which case you can
+push your feature branch, then open a pull request, selecting the ``main``
+branch as the base branch.
+
+If you are not an SO collaborator, or otherwise do not have push access, we
+still welcome your pull request! You will have to fork the repository and
+submit a PR from there. See the `GitHub documentation
+<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork>`_
+for details on how to do so.
 
 Releases
 --------
@@ -28,21 +51,17 @@ Releases
 
 If you are trying to issue a release of OCS you should follow these steps:
 
-1. Open a Pull Request, comparing ``develop`` to the ``master`` base branch.
-   Describe the features added for this release.
-2. Make a merge commit when you merge this PR.
-
-   * This merge commit will be what is tagged for the release.
-   * ``develop`` is now one commit behind ``master`` (the merge commit)
-
-3. Pull the latest ``master`` and ``develop`` branches to your work station.
-4. Checkout ``develop``, then run ``git merge --ff-only master``, catching ``develop`` up to ``master``.
-5. ``push origin develop`` to update the remote ``develop`` branch.
-
-The ``develop`` and ``master`` branches are now aligned, and ``master`` is
-ready to be released. You can use the GitHub release interface to create a new
-release, copying the change log you wrote in the PR and otherwise describing the
-release.
+1. Test the release properly builds and publishes with a pre-release. You can
+   do so by pushing a tag matching ``v0.*.*a*``, ``v0.*.*b*``, or
+   ``v0.*.*rc*``.
+2. If no new commits are made following a pre-release, remove the pre-release
+   tag. Multiple tags may prevent the official release from publishing properly.
+3. Use the GitHub releases interface to draft a new release, creating a new tag
+   targeting the ``main`` branch.
+4. Write the release notes. Make use of the "Generate release notes" feature.
+   It is helpful to organize these into sections as done in past releases. Be
+   sure to highlight any breaking changes and include instructions for any
+   actions users must take when updating.
 
 Development Guide
 -----------------
@@ -58,7 +77,7 @@ As a way to enforce development guide recommendations we have configured
 when contributing to ocs. It will save both you and the reviewers time when
 submitting pull requests.
 
-You should set this up before making and commiting your changes. To do so make
+You should set this up before making and committing your changes. To do so make
 sure the ``pre-commit`` package is installed::
 
     $ pip install pre-commit
@@ -110,9 +129,5 @@ and then re-run the commit. Here is the expected git output for this example:
         modified:   demo.py
     $ git add -u
     $ git commit
-
-**Note:** This is a new tool to this repo, and the flake8 output might still be
-somewhat strict. If there are warnings that you think should be ignored, please
-bring this up for discussion in a new issue.
 
 .. _pre-commit: https://pre-commit.com/

--- a/README.rst
+++ b/README.rst
@@ -2,12 +2,12 @@
 OCS - Observatory Control System
 ================================
 
-.. image:: https://img.shields.io/github/workflow/status/simonsobs/ocs/Build%20Develop%20Images
-    :target: https://github.com/simonsobs/ocs/actions?query=workflow%3A%22Build+Develop+Images%22
+.. image:: https://img.shields.io/github/workflow/status/simonsobs/ocs/Build%20Test%20Images
+    :target: https://github.com/simonsobs/ocs/actions?query=workflow%3A%22Build+Test+Images%22
     :alt: GitHub Workflow Status
 
-.. image:: https://readthedocs.org/projects/ocs/badge/?version=develop
-    :target: https://ocs.readthedocs.io/en/develop/?badge=develop
+.. image:: https://readthedocs.org/projects/ocs/badge/?version=main
+    :target: https://ocs.readthedocs.io/en/main/?badge=main
     :alt: Documentation Status
 
 .. image:: https://coveralls.io/repos/github/simonsobs/ocs/badge.svg
@@ -20,8 +20,8 @@ OCS - Observatory Control System
    :target: https://pypi.org/project/ocs/
    :alt: PyPI Package
 
-.. image:: https://results.pre-commit.ci/badge/github/simonsobs/ocs/develop.svg
-   :target: https://results.pre-commit.ci/latest/github/simonsobs/ocs/develop
+.. image:: https://results.pre-commit.ci/badge/github/simonsobs/ocs/main.svg
+   :target: https://results.pre-commit.ci/latest/github/simonsobs/ocs/main
    :alt: pre-commit.ci status
 
 Overview
@@ -76,9 +76,9 @@ If you need to install the optional so3g module you can do so via::
 Installing from Source
 ``````````````````````
 
-If you are considering contributing to OCS, or would like to use the
-development branch, you will want to install from source. To do so, clone this
-repository and install using pip::
+If you are considering contributing to OCS, or would like to use an unreleased
+feature, you will want to install from source. To do so, clone this repository
+and install using pip::
 
   $ git clone https://github.com/simonsobs/ocs.git
   $ cd ocs/
@@ -95,11 +95,10 @@ releases will be tagged with their release version, i.e. ``v0.1.0``. These are
 only built on release, and the ``latest`` tag will point to the latest of these
 released tags. These should be considered stable.
 
-Development images will be tagged with the latest released version tag, the
-number of commits ahead of that release, the latest commit hash, and the tag
-``-dev``, i.e.  ``v0.6.0-53-g0e390f6-dev``. These get built on each commit to
-the ``develop`` branch, and are useful for testing and development, but should
-be considered unstable.
+Test images will be tagged with the latest released version tag, the number of
+commits ahead of that release, the latest commit hash, i.e.
+``v0.6.0-53-g0e390f6``. These get built on each commit to the ``main`` branch,
+and are useful for testing and development, but should be considered unstable.
 
 .. _Docker Hub: https://hub.docker.com/u/simonsobs
 
@@ -135,7 +134,7 @@ then use docker run::
 
 For more details see `tests/README.rst <tests_>`_.
 
-.. _tests: https://github.com/simonsobs/ocs/blob/master/tests/README.rst
+.. _tests: https://github.com/simonsobs/ocs/blob/main/tests/README.rst
 
 Example
 -------
@@ -144,18 +143,18 @@ A self contained example, demonstrating the operation of a small observatory
 with a single OCS Agent is contained in `example/miniobs/`_.  See the `readme`_
 in that directory for details.
 
-.. _example/miniobs/: https://github.com/simonsobs/ocs/tree/master/example/miniobs
-.. _readme: https://github.com/simonsobs/ocs/blob/master/example/miniobs/README.rst
+.. _example/miniobs/: https://github.com/simonsobs/ocs/tree/main/example/miniobs
+.. _readme: https://github.com/simonsobs/ocs/blob/main/example/miniobs/README.rst
 
 Contributing
 ------------
 For guidelines on how to contribute to OCS see `CONTRIBUTING.rst`_.
 
-.. _CONTRIBUTING.rst: https://github.com/simonsobs/ocs/blob/master/CONTRIBUTING.rst
+.. _CONTRIBUTING.rst: https://github.com/simonsobs/ocs/blob/main/CONTRIBUTING.rst
 
 License
 --------
 This project is licensed under the BSD 2-Clause License - see the
 `LICENSE.txt`_ file for details.
 
-.. _LICENSE.txt: https://github.com/simonsobs/ocs/blob/master/LICENSE.txt
+.. _LICENSE.txt: https://github.com/simonsobs/ocs/blob/main/LICENSE.txt

--- a/docs/developer/agent_references/documentation.rst
+++ b/docs/developer/agent_references/documentation.rst
@@ -120,7 +120,7 @@ Agent Reference Pages
 Now that you have documented your Agent's Tasks and Processes appropriately we
 need to make the page that will display that documentation. Agent reference
 pages are kept in `ocs/docs/agents/
-<https://github.com/simonsobs/ocs/tree/develop/docs/agents>`_. Each Agent has a
+<https://github.com/simonsobs/ocs/tree/main/docs/agents>`_. Each Agent has a
 separate `.rst` file.  Each Agent reference page must contain:
 
 * Brief description of the Agent

--- a/docs/developer/docker.rst
+++ b/docs/developer/docker.rst
@@ -12,7 +12,7 @@ OCS Base Image
 --------------
 
 The OCS base image is built from the `Dockerfile
-<https://github.com/simonsobs/ocs/blob/develop/Dockerfile>`_ in the root of the
+<https://github.com/simonsobs/ocs/blob/main/Dockerfile>`_ in the root of the
 respository, shown here:
 
 .. literalinclude:: ../../Dockerfile

--- a/docs/user/crossbar_config.rst
+++ b/docs/user/crossbar_config.rst
@@ -30,8 +30,8 @@ roles of "iocs_agent" and "iocs_controller, and "address_root" of
 For further details on crossbar server configuration, see the crossbar `Router
 Configuration`_ page.
 
-.. _`ocs/docker/crossbar/config.json`: https://github.com/simonsobs/ocs/blob/develop/docker/crossbar/config.json
-.. _`ocs/ocs/support/crossbar_config.json`: https://github.com/simonsobs/ocs/blob/develop/ocs/support/crossbar_config.json
+.. _`ocs/docker/crossbar/config.json`: https://github.com/simonsobs/ocs/blob/main/docker/crossbar/config.json
+.. _`ocs/ocs/support/crossbar_config.json`: https://github.com/simonsobs/ocs/blob/main/ocs/support/crossbar_config.json
 .. _`Router Configuration`: https://crossbar.io/docs/Router-Configuration/
 
 Generating a New Config File

--- a/ocs/ocsbow.py
+++ b/ocs/ocsbow.py
@@ -22,7 +22,7 @@ across the observatory be started or stopped.
 EPILOG = """
 More info for each command is available by adding --help, e.g. "ocsbow up --help".
 
-For more details, see https://ocs.readthedocs.io/en/develop/user/cli_tools.html#ocsbow.
+For more details, see https://ocs.readthedocs.io/en/main/user/cli_tools.html#ocsbow.
 """
 
 # agent_class of the HostManager.
@@ -876,7 +876,7 @@ Or with a target subsystem::
 """
 
 LOCAL_EPILOG = """For more details, see
-https://ocs.readthedocs.io/en/develop/user/cli_tools.html#ocs-local-support."""
+https://ocs.readthedocs.io/en/main/user/cli_tools.html#ocs-local-support."""
 
 
 def get_parser_local():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The split ``master`` and ``develop`` branching model was convenient when people were installing from source. But now that things are on PyPI, and the agents are packaged, this model only really serves to make releases cumbersome to perform.

I've created a new ``main`` branch. This will be made the default branch (effectively replacing ``develop``.) The old branches will stick around for a bit while we migrate.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Releases are cumbersome to make, and stable installations can now be done via PyPI (or on version tags here from the repo.)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've checked some things in this branch. The external services used will need some updates, so some stuff will be broken until we take the plunge, i.e. readthedocs, coverage, etc.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
