### PR TITLE
Separate blocks for each registered operation

### DIFF
--- a/ocs/agents/registry/agent.py
+++ b/ocs/agents/registry/agent.py
@@ -135,8 +135,8 @@ class Registry:
                 self.log.warn(f"Improper field name: {field}\n{e}")
                 continue
             msg = {'block_name': field,
-                'timestamp': time.time(),
-                'data': dict(field=op_code)}
+                   'timestamp': time.time(),
+                   'data': dict(field=op_code)}
             self.agent.publish_to_feed('agent_operations', msg)
 
     @ocs_agent.param('test_mode', default=False, type=bool)

--- a/ocs/agents/registry/agent.py
+++ b/ocs/agents/registry/agent.py
@@ -145,7 +145,7 @@ class Registry:
                 continue
             msg = {'block_name': field,
                    'timestamp': time.time(),
-                   'data': dict(field=op_code)}
+                   'data': {field: op_code}}
             self.agent.publish_to_feed('agent_operations', msg)
 
     @ocs_agent.param('test_mode', default=False, type=bool)

--- a/ocs/agents/registry/agent.py
+++ b/ocs/agents/registry/agent.py
@@ -123,9 +123,6 @@ class Registry:
 
     def _publish_agent_ops(self, reg_agent):
         addr = reg_agent.agent_address
-        msg = {'block_name': addr,
-               'timestamp': time.time(),
-               'data': {}}
         self.log.debug(addr)
         for op_name, op_code in reg_agent.op_codes.items():
             field = f'{addr}_{op_name}'
@@ -137,8 +134,9 @@ class Registry:
             except ValueError as e:
                 self.log.warn(f"Improper field name: {field}\n{e}")
                 continue
-            msg['data'][field] = op_code
-        if msg['data']:
+            msg = {'block_name': field,
+                'timestamp': time.time(),
+                'data': dict(field=op_code)}
             self.agent.publish_to_feed('agent_operations', msg)
 
     @ocs_agent.param('test_mode', default=False, type=bool)

--- a/tests/agents/test_registry_agent.py
+++ b/tests/agents/test_registry_agent.py
@@ -1,5 +1,4 @@
 import time
-import pytest
 import pytest_twisted
 
 from agents.util import create_session, create_agent_fixture
@@ -120,5 +119,4 @@ def test_registry_handles_changed_agent_ops(agent):
 
     # Add a new op to the registered agent
     reg_agent.op_codes = {'op_name': 1, 'new_op': 1}
-    with pytest.raises(Exception):
-        agent._publish_agent_ops(reg_agent)
+    agent._publish_agent_ops(reg_agent)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes registry block structure so that each operation has its own block.


## Description
It is possible for the operation list of an agent to change, if that agent is updated without restarting the registry. This will crash the registry and prevent it from publishing data since the block-structure of the feed depends on the available agents. This changes the registry so that each operation has its own block, allowing for the operation list to change without crashing the registry.

## Motivation and Context
Solves issues where updating agents without restarting the registry causes it to crash. 
Resolves #311.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran registry tests locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
