### PR TITLE
Test/development portability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.rst", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 so3g_etxras = ["so3g"]
-dev_extras = ["pytest", "pytest_twisted", "pytest-docker-compose", "pytest-cov", "coverage"]
+dev_extras = ["pytest", "pytest-twisted", "pytest-docker-compose", "pytest-cov", "coverage", "docker"]
 dev_extras.extend(so3g_etxras)
 
 setup(name='ocs',

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,10 @@ import versioneer
 with open("README.rst", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
+so3g_etxras = ["so3g"]
+dev_extras = ["pytest", "pytest_twisted", "pytest-docker-compose", "pytest-cov", "coverage"]
+dev_extras.extend(so3g_etxras)
+
 setup(name='ocs',
       description='Observatory Control System',
       long_description=long_description,
@@ -50,6 +54,7 @@ setup(name='ocs',
           'numpy',
       ],
       extras_require={
-          "so3g": ["so3g"],
+          "so3g": so3g_etxras,
+          "dev": dev_extras,
       },
       )

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   # Crossbar Server
   # --------------------------------------------------------------------------
   crossbar:
-    image: ocs-crossbar
+    image: simonsobs/ocs-crossbar
     container_name: "ocs-tests-crossbar"
     ports:
       - "18001:18001" # expose for OCS
@@ -22,7 +22,7 @@ services:
   # OCS Components
   # --------------------------------------------------------------------------
   fake-data1:
-    image: ocs
+    image: simonsobs/ocs
     container_name: "ocs-tests-fake-data-agent"
     hostname: ocs-docker
     volumes:
@@ -33,7 +33,7 @@ services:
       - SITE_HTTP=http://ocs-tests-crossbar:18001/call
 
   ocs-aggregator:
-    image: ocs
+    image: simonsobs/ocs
     hostname: ocs-docker
     volumes:
       - ./default.yaml:/config/default.yaml:ro

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   # Crossbar Server
   # --------------------------------------------------------------------------
   crossbar:
-    image: simonsobs/ocs-crossbar
+    image: ocs-crossbar
     container_name: "ocs-tests-crossbar"
     ports:
       - "18001:18001" # expose for OCS
@@ -22,7 +22,7 @@ services:
   # OCS Components
   # --------------------------------------------------------------------------
   fake-data1:
-    image: simonsobs/ocs
+    image: ocs
     container_name: "ocs-tests-fake-data-agent"
     hostname: ocs-docker
     volumes:
@@ -33,7 +33,7 @@ services:
       - SITE_HTTP=http://ocs-tests-crossbar:18001/call
 
   ocs-aggregator:
-    image: simonsobs/ocs
+    image: ocs
     hostname: ocs-docker
     volumes:
       - ./default.yaml:/config/default.yaml:ro

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -424,7 +424,6 @@ def test_make_filename_directory_creation_no_subdirs(tmpdir):
         make_filename(test_dir, make_subdirs=False)
 
 
-@patch('os.makedirs', side_effect=PermissionError('mocked permission error'))
 def test_make_filename_directory_creation_permissions(tmpdir):
     """make_filename() should raise a PermissionError if it runs into one when
     making the directories.
@@ -433,6 +432,7 @@ def test_make_filename_directory_creation_permissions(tmpdir):
 
     """
     test_dir = os.path.join(tmpdir, 'data')
-    with pytest.raises(PermissionError) as e_info:
-        make_filename(test_dir)
-    assert str(e_info.value) == 'mocked permission error'
+    with patch('os.makedirs', side_effect=PermissionError('mocked permission error')):
+        with pytest.raises(PermissionError) as e_info:
+            make_filename(test_dir)
+        assert str(e_info.value) == 'mocked permission error'

--- a/tests/test_ocs_agent.py
+++ b/tests/test_ocs_agent.py
@@ -50,6 +50,7 @@ def mock_agent():
     """
     mock_config = MagicMock()
     mock_site_args = MagicMock()
+    mock_site_args.working_dir = "./"
     mock_site_args.log_dir = "./"
     a = OCSAgent(mock_config, mock_site_args, address='test.address')
     return a


### PR DESCRIPTION
This patch collects changes I needed to make to run the tests locally when developing. 

## Description
This includes:
- Adding a set of optional development dependencies (`pytest`, etc.)
- Fixing docker image names so that pulls from dockerhub succeed
- Fixing test failures from calling `os.path.join` on mock objects

## Motivation and Context
Without these changes, I could not run the tests in a clean venv (because testing packages are not installed by default), and when i installed these I got large numbers of test failures. 

## How Has This Been Tested?
After making these changes, and using the new `pip install .[dev]` option all tests run and pass. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
