### PR TITLE
A possible implementation for managing non-python agents

### DIFF
--- a/ocs/agents/host_manager/drivers.py
+++ b/ocs/agents/host_manager/drivers.py
@@ -17,6 +17,8 @@ class ManagedInstance(dict):
     - 'agent_class' (str): The agent class.  This will have special
       value 'docker' if the instance corresponds to a docker-compose
       service that has not been matched to a site_config entry.
+    - 'agent_exe' (str): The agent executable. This setting is mutually
+      exclusive with 'agent_class'.
     - 'instance_id' (str): The agent instance-id, or the docker
       service name if the instance is an unmatched docker-compose
       service.
@@ -214,7 +216,7 @@ def stability_factor(times, window=120):
 
 
 class AgentProcessHelper(protocol.ProcessProtocol):
-    def __init__(self, instance_id, cmd):
+    def __init__(self, instance_id, cmd, log_file=None):
         super().__init__()
         self.status = None, None
         self.killed = False
@@ -222,6 +224,7 @@ class AgentProcessHelper(protocol.ProcessProtocol):
         self.cmd = cmd
         self.lines = {'stderr': [],
                       'stdout': []}
+        self.log_file = open(log_file,"ab") if log_file is not None else None
 
     def up(self):
         reactor.spawnProcess(self, self.cmd[0], self.cmd[:], env=os.environ)
@@ -231,6 +234,8 @@ class AgentProcessHelper(protocol.ProcessProtocol):
         # race condition, but it could be worse.
         if self.status[0] is None:
             reactor.callFromThread(self.transport.signalProcess, 'INT')
+        if self.log_file is not None:
+            self.log_file.flush()
 
     # See https://twistedmatrix.com/documents/current/core/howto/process.html
     #
@@ -262,11 +267,15 @@ class AgentProcessHelper(protocol.ProcessProtocol):
         self.status = status, time.time()
 
     def outReceived(self, data):
+        if self.log_file is not None:
+            self.log_file.write(data)
         self.lines['stdout'].extend(data.decode('utf8').split('\n'))
         if len(self.lines['stdout']) > 100:
             self.lines['stdout'] = self.lines['stdout'][-100:]
 
     def errReceived(self, data):
+        if self.log_file is not None:
+            self.log_file.write(data)
         self.lines['stderr'].extend(data.decode('utf8').split('\n'))
         if len(self.lines['stderr']) > 100:
             self.lines['stderr'] = self.lines['stderr'][-100:]


### PR DESCRIPTION
This is a tentative set of changes to support managing agents (or indeed any program) which are not written in python (and without using Docker).

## Description
This change allows agents to be specified with an executable, `agent-exe`, as an alternative to `agent-class`. If this is done, the executable is run directly, rather than running the python interpreter on a script or module. 

Arguments are passed somewhat differently to agent executables: The `agent_arguments` are passed directly, and the WAMP (router) URL and realm are passed, instead of the OCS site file and host. Additionally, the instance ID passed to the child is fully qualified, with the OCS address root. The logic for this is to avoid every agent having to reimplement the OCS config parsing logic, when the HostManager has already done the parsing, and has all necessary information available to it to pass on. The disadvantage is that handling of python and generic agents is not symmetric. 

A `capture_logs` boolean option is added for agents. When this is enabled, the `AgentProcessHelper` writes data captured from stdout/stderr to a file alongside existing logs. This is not fancy, but at least ensures that log data from programs which write normally to stdout/stderr can be checked. 

These changes are orthogonal to, and should not interfere with, the existing Docker agent management mechanism/encoding, but it is somewhat dissatisfying that python, docker, and generic code paths are not more parallel. The hope is that this avoids breaking any of the Docker handling, which I cannot easily test, but it is not very elegant. 

## Motivation and Context
I would like to manage agents which are not written in python due to their requirements for multi-threading and low-latency operation on high data volumes, e.g. the CMB-S4 DAQ collector prototype. It is already possible for such agents to communicate over WAMP to publish and subscribe to data feeds and have operations controlled with an `OCSClient` without changes to OCS, but it is also desirable to be able to manage their lifetimes (via `ocsbow`, and the `HostManager`, etc.) as well. 

## How Has This Been Tested?
All tests in the test suite pass, and I am successfully able to manage (bring up, keep running, shut down, and view logs) a C++ agent alongside standard python agents on an Ubuntu host. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Documentation of these features is still missing; I will be happy to write it if/when we converge on the implementation details. I am also not entirely sure that there are not gaps in my implementation; I have tested by running my own use-case (with both python and non-python agents), and the test suite, but I don't have a good feel for the completeness of the coverage that provides. 