### PR TITLE
Add `importlib_metadata` dependency for ocs-agent-cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(name='ocs',
           'PyYAML',
           'influxdb',
           'numpy',
+          'importlib_metadata;python_version<"3.10"',
       ],
       extras_require={
           "so3g": ["so3g"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds `importlib_metadata` as a dependency for python versions below 3.10, as used in `ocs-agent-cli`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ran into this missing dependency on an older system with Python 3.8.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Installed in a clean python3.8 and python 3.10 environment to check the python version dependent install, and ran `ocs-agent-cli` to confirm missing module error went away.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
