### PR TITLE
Access control

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -88,6 +88,14 @@ ocs.agent_cli
 
 .. _ocs_base_api:
 
+ocs.access
+----------
+
+.. automodule:: ocs.access
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 ocs.base
 --------
 

--- a/docs/developer/access-control.rst
+++ b/docs/developer/access-control.rst
@@ -1,0 +1,3 @@
+Access Control
+==============
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,7 @@ write OCS Agents or Clients.
     developer/clients
     developer/data
     developer/writing-plugins
+    developer/access-control
     developer/docker
     developer/testing
 

--- a/ocs/access.py
+++ b/ocs/access.py
@@ -95,14 +95,14 @@ def no_hash(x):
     return x
 
 
-def get_creds(credentials, rules, op_name=None, action=None):
-    """Based on the current access control rules, and the credentials
+def get_creds(password, rules, op_name=None, action=None):
+    """Based on the current access control rules, and the password
     provided by the client, determine what credential level this
     client has.
 
     Args:
-      credentials (str): the password (unhashed) supplied by the
-        client.
+
+      password (str): the password (unhashed) supplied by the client.
       rules (dict): the access rules dict.
       op_name (str): the operation being accessed.
       action (str): the action being called on the operation.
@@ -111,7 +111,7 @@ def get_creds(credentials, rules, op_name=None, action=None):
       A CredLevel.
 
     """
-    if credentials is None or credentials == '':
+    if password is None or password == '':
         return CredLevel(1)
 
     for k, level in [('password-2', CredLevel(2)),
@@ -126,7 +126,7 @@ def get_creds(credentials, rules, op_name=None, action=None):
             print(f'Warning: invalid hash function {rule["hash"]}')
             continue
 
-        if hashfunc(credentials) == rule['value']:
+        if hashfunc(password) == rule['value']:
             return level
 
     return CredLevel(1)
@@ -143,8 +143,8 @@ def rejection_message(cred_level: CredLevel, access_level: AccessLevel):
 
 
 def get_client_password(privs, agent_class, instance_id):
-    """Determine the best client password to use.  This may lead to
-    inspection of OCS password files.
+    """For OCSClient use -- determine the best client password to use.
+    This may lead to inspection of OCS password files.
 
     Args:
       privs (str or int): Either a string representing a password to
@@ -158,7 +158,7 @@ def get_client_password(privs, agent_class, instance_id):
     Returns:
       A string representing the password to use in all requests the
       client makes (these are passed to the agent in the
-      "credentials=..." argument of the _ops_handler).
+      "password=..." argument of the _ops_handler).
 
     Notes:
       If privs is a string, then this password is used directly and no
@@ -223,11 +223,11 @@ def get_client_password(privs, agent_class, instance_id):
         return ''
 
     if os.getenv('OCS_PASSWORDS_FILE'):
-        cred_file = os.getenv('OCS_PASSWORDS_FILE')
+        pw_file = os.getenv('OCS_PASSWORDS_FILE')
     else:
-        cred_file = os.path.expanduser('~/.ocs-passwords.yaml')
+        pw_file = os.path.expanduser('~/.ocs-passwords.yaml')
 
-    creds = yaml.safe_load(open(cred_file, 'rb'))
+    creds = yaml.safe_load(open(pw_file, 'rb'))
     for row in creds:
         _d = row.get('default')
         _a = row.get('agent-class')

--- a/ocs/access.py
+++ b/ocs/access.py
@@ -1,0 +1,56 @@
+"""Access Control is a system for restricting access to some Agents or
+Agent functions to certain clients.
+
+"""
+
+from enum import Enum
+
+class CredLevel(Enum):
+    """The credential level of a client."""
+    BLOCKED = 0
+    BASIC = 1
+    ADVANCED = 2
+    FULL = 3
+    SUPERUSER = 4
+    def encode(self):
+        return f'{self.value}-{self.name}'
+
+class AccessLevel(Enum):
+    """The minimum credential level that is required to access an
+    endpoint.
+
+    Compare to a CredLevel using .value, e.g.::
+
+      if cred_level.value >= access_level.value:
+        do_the_thing()
+
+    """
+    BASIC = 1
+    ADVANCED = 2
+    FULL = 3
+    def encode(self):
+        return f'{self.value}-{self.name}'
+
+def get_creds(credentials, rules, op_name=None, action=None):
+    """Based on the current access control rules, and the credentials
+    provided by the client, determine what credential level this
+    client has.
+
+    Returns:
+      A CredLevel.
+
+    """
+    # Interim, let the client state its credential level as an
+    # integer.
+    if isinstance(credentials, int) and credentials > 1:
+        return CredLevel(credentials)
+    return CredLevel(1)
+
+def rejection_message(cred_level: CredLevel, access_level: AccessLevel):
+    """Get a helpful message about what privs are needed to access a
+    resource protected at access_level.
+
+    """
+    assert(cred_level.value < access_level.value)
+    return 'The action requires privileges %s but the client has only %s' % (
+        access_level.encode(), cred_level.encode())

--- a/ocs/access.py
+++ b/ocs/access.py
@@ -3,6 +3,8 @@ Agent functions to certain clients.
 
 """
 
+import os
+import yaml
 from enum import Enum
 
 class CredLevel(Enum):
@@ -40,10 +42,12 @@ def get_creds(credentials, rules, op_name=None, action=None):
       A CredLevel.
 
     """
-    # Interim, let the client state its credential level as an
-    # integer.
-    if isinstance(credentials, int) and credentials > 1:
-        return CredLevel(credentials)
+    if credentials is None or credentials == '':
+        return CredLevel(1)
+    for k, level in [('password-2', CredLevel(2)),
+                     ('password-3', CredLevel(3))]:
+        if credentials == rules.get(k):
+            return level
     return CredLevel(1)
 
 def rejection_message(cred_level: CredLevel, access_level: AccessLevel):
@@ -54,3 +58,104 @@ def rejection_message(cred_level: CredLevel, access_level: AccessLevel):
     assert(cred_level.value < access_level.value)
     return 'The action requires privileges %s but the client has only %s' % (
         access_level.encode(), cred_level.encode())
+
+def get_client_password(privs, agent_class, instance_id):
+    """Determine the best client password to use.  This may lead to
+    inspection of OCS password files.
+
+    Args:
+      privs (str or int): Either a string representing a password to
+        use, or an integer (1, 2, 3) representing the Access Level
+        that is desired.
+      agent_class (str or None): If specified, will be used to match
+        rules in the password config file.
+      instance_id (str or None): If specified, will be used to match
+        rules in the password config file.
+
+    Returns:
+      A string representing the password to use in all requests the
+      client makes (these are passed to the agent in the
+      "credentials=..." argument of the _ops_handler).
+
+    Notes:
+
+      If privs is a string, then this password is used directly and no
+      inspection of config files is performend.
+
+      If privs is 1, then the password '' is returned.
+
+      If privs is 2 or 3, then the OCS password file is loaded and
+      inspected for a suitable password.  The password file will be
+      loaded from ~/.ocs-passwords.yaml, unless overridden by the
+      environment variable OCS_PASSWORD_FILE.
+
+      The OCS_PASSWORD_FILE must be yaml containing a single list.
+      Each entry in the list is a dictionary referred to as a rule.
+
+      A rule must have the following format::
+
+        {
+          <selector>: <value to match>
+          'password-2': <password for level 2 access>,
+          'password-3': <password for level 3 access>,
+        }
+
+      The "selector" must be either "agent-class", "instance-id", or
+      "default" (in the case of default, the value to match should
+      also be set to default).  It is permitted to include both an
+      agent-class and a n instance-id selector, in which case both
+      must be matched.
+
+      Here's an example::
+
+        - agent-class: FakeDataAgent
+          password-2: fake-pw-2
+          password-3: fake-pw-3
+
+        - instance-id: registry
+          password-3: please-let-me-register
+
+        - default: default
+          password-2: general-level2-password
+          password-3: general-level2-password
+
+      When attempting to find a password, the *first* rule that
+      matches will be used.  This means that the rules should be
+      organized from most specific to least specific.
+
+      If privs=2 is requested, and a matching rule is found, but the
+      password-2 is not specified, then the password-3 value will be
+      returned if present.
+
+    """
+
+    if isinstance(privs, str):
+        return privs
+    if privs is None:
+        privs = 1
+    if not isinstance(privs, int):
+        raise ValueError("privs argument should be int or str.")
+        assert(1 <= privs <= 3)
+
+    if privs == 1:
+        return ''
+
+    if os.getenv('OCS_PASSWORDS_FILE'):
+        cred_file = os.getenv('OCS_PASSWORDS_FILE')
+    else:
+        cred_file = os.path.expanduser('~/.ocs-passwords.yaml')
+
+    creds = yaml.safe_load(open(cred_file, 'rb'))
+    for row in creds:
+        _d = row.get('default')
+        _a = row.get('agent-class')
+        _i = row.get('instance-id')
+        if (_d is not None) or (
+                (_a is None or _a == agent_class) and \
+                (_i is None or _i == instance_id)):
+            if 'password-2' in row and privs <= 2:
+                return row['password-2']
+            if 'password-3' in row and privs <= 3:
+                return row['password-3']
+
+    return ''

--- a/ocs/agents/fake_data/agent.py
+++ b/ocs/agents/fake_data/agent.py
@@ -286,6 +286,13 @@ def main(args=None):
 
     agent, runner = ocs_agent.init_site_agent(args)
 
+    # If user specifies an Access Policy, we will make "delay_task"
+    # require "Advanced" access to help with testing.
+    if args.access_policy is None:
+        min_privs = 1
+    else:
+        min_privs = 2
+
     fdata = FakeDataAgent(agent,
                           num_channels=args.num_channels,
                           sample_rate=args.sample_rate,
@@ -296,7 +303,8 @@ def main(args=None):
                            blocking=False, startup=startup)
     agent.register_task('set_heartbeat', fdata.set_heartbeat)
     agent.register_task('delay_task', fdata.delay_task, blocking=False,
-                        aborter=fdata._abort_delay_task)
+                        aborter=fdata._abort_delay_task,
+                        min_privs=min_privs)
 
     runner.run(agent, auto_reconnect=True)
 

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -269,17 +269,17 @@ class OCSAgent(ApplicationSession):
             'processes': list(self.processes.keys())
         }
 
-    def _ops_handler(self, action, op_name, params=None, timeout=None, credentials=None):
+    def _ops_handler(self, action, op_name, params=None, timeout=None, password=None):
         if action == 'start':
-            return self.start(op_name, params=params, credentials=credentials)
+            return self.start(op_name, params=params, password=password)
         if action == 'stop':
-            return self.stop(op_name, params=params, credentials=credentials)
+            return self.stop(op_name, params=params, password=password)
         if action == 'abort':
-            return self.abort(op_name, params=params, credentials=credentials)
+            return self.abort(op_name, params=params, password=password)
         if action == 'wait':
-            return self.wait(op_name, timeout=timeout, credentials=credentials)
+            return self.wait(op_name, timeout=timeout, password=password)
         if action == 'status':
-            return self.status(op_name, credentials=credentials)
+            return self.status(op_name, password=password)
         return (ocs.ERROR, 'No implementation for "%s"' % op_name, {})
 
     def _gather_sessions(self, parent):
@@ -648,7 +648,7 @@ class OCSAgent(ApplicationSession):
     Agent's Operations.  Some methods are valid on Processs, some on
     Tasks, and some on both."""
 
-    def start(self, op_name, params=None, credentials=None):
+    def start(self, op_name, params=None, password=None):
         """
         Launch an operation.  Note that successful return of this function
         does not mean that the operation is running; it only means
@@ -688,7 +688,7 @@ class OCSAgent(ApplicationSession):
                 msg = 'Started process "%s".' % op_name
 
             # Check access.
-            cred_level = access.get_creds(credentials, self.rules,
+            cred_level = access.get_creds(password, self.rules,
                                           op_name=op_name, action='start')
             if cred_level.value < op.min_privs.value:
                 return (ocs.ERROR,
@@ -727,7 +727,7 @@ class OCSAgent(ApplicationSession):
             return (ocs.ERROR, 'No task or process called "%s"' % op_name, {})
 
     @inlineCallbacks
-    def wait(self, op_name, timeout=None, credentials=None):
+    def wait(self, op_name, timeout=None, password=None):
         """Wait for the specified Operation to become idle, or for timeout
         seconds to elapse.  If timeout==None, the timeout is disabled
         and the function will not return until the Operation
@@ -792,7 +792,7 @@ class OCSAgent(ApplicationSession):
             return (ocs.TIMEOUT, 'Operation "%s" still running; wait timed out.' % op_name,
                     session.encoded())
 
-    def _stop_helper(self, stop_type, op_name, params, credentials):
+    def _stop_helper(self, stop_type, op_name, params, password):
         """Common stopper/aborter code for Process stop and Task
         abort.
 
@@ -801,7 +801,7 @@ class OCSAgent(ApplicationSession):
           op_name (str): the op_name.
           params (dict or None): Params to be passed to stopper
             function.
-          credentials: Credentials of the client.
+          password: Password of the client.
 
         """
         print(f'{stop_type} called for {op_name}')
@@ -826,7 +826,7 @@ class OCSAgent(ApplicationSession):
             return (ocs.ERROR, f'Cannot "{stop_type}" "{op_name}" because '
                     'it is a "{op_type}".', {})
 
-        cred_level = access.get_creds(credentials, self.rules,
+        cred_level = access.get_creds(password, self.rules,
                                       op_name=op_name, action=stop_type)
         if cred_level.value < op.min_privs.value:
             return (ocs.ERROR,
@@ -881,7 +881,7 @@ class OCSAgent(ApplicationSession):
         return (ocs.OK, f'Requested {stop_type} on {op_type} {op_name}".',
                 session.encoded())
 
-    def stop(self, op_name, params=None, credentials=None):
+    def stop(self, op_name, params=None, password=None):
         """
         Initiate a Process stop routine.
 
@@ -894,9 +894,9 @@ class OCSAgent(ApplicationSession):
 
           ocs.OK: the Process stop routine has been launched.
         """
-        return self._stop_helper('stop', op_name, params, credentials)
+        return self._stop_helper('stop', op_name, params, password)
 
-    def abort(self, op_name, params=None, credentials=None):
+    def abort(self, op_name, params=None, password=None):
         """
         Initiate a Task abort routine.
 
@@ -910,9 +910,9 @@ class OCSAgent(ApplicationSession):
           ocs.OK: the Process stop routine has been launched.
 
         """
-        return self._stop_helper('abort', op_name, params, credentials)
+        return self._stop_helper('abort', op_name, params, password)
 
-    def status(self, op_name, params=None, credentials=None):
+    def status(self, op_name, params=None, password=None):
         """
         Get an Operation's session data.
 

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -110,10 +110,8 @@ class OCSAgent(ApplicationSession):
         self.realm_joined = False
         self.first_time_startup = True
 
-        self.rules = {
-            'password-2': 'fake-pw-2',
-            'password-3': 'fake-pw-3',
-        }
+        # Access Control rules
+        self.rules = access.get_policy_default(site_args.access_policy)
 
         # Attach the logger.
         log_dir, log_file = site_args.log_dir, None

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -110,7 +110,10 @@ class OCSAgent(ApplicationSession):
         self.realm_joined = False
         self.first_time_startup = True
 
-        self.rules = None
+        self.rules = {
+            'password-2': 'fake-pw-2',
+            'password-3': 'fake-pw-3',
+        }
 
         # Attach the logger.
         log_dir, log_file = site_args.log_dir, None

--- a/ocs/ocs_client.py
+++ b/ocs/ocs_client.py
@@ -16,26 +16,26 @@ def _get_op(op_type, name, encoded, client, password):
             :class:`ocs.ocs_agent.AgentProcess` dictionary.
         client (ControlClient): Client object, which will be used to issue the
             requests for operation actions.
-        password (str): Client credentials (a password).
+        password (str): Client-supplied password.
 
     """
     class MatchedOp:
         def start(self, **kwargs):
             return OCSReply(*client.request('start', name, params=kwargs,
-                                            credentials=password))
+                                            password=password))
 
         def wait(self, timeout=None):
             return OCSReply(*client.request('wait', name, timeout=timeout,
-                                            credentials=password))
+                                            password=password))
 
         def status(self):
             return OCSReply(*client.request('status', name,
-                                            credentials=password))
+                                            password=password))
 
     class MatchedTask(MatchedOp):
         def abort(self):
             return OCSReply(*client.request('abort', name,
-                                            credentials=password))
+                                            password=password))
 
         def __call__(self, **kw):
             """Runs self.start(**kw) and, if that succeeds, self.wait()."""
@@ -47,7 +47,7 @@ def _get_op(op_type, name, encoded, client, password):
     class MatchedProcess(MatchedOp):
         def stop(self):
             return OCSReply(*client.request('stop', name,
-                                            credentials=password))
+                                            password=password))
 
         def __call__(self):
             """Equivalent to self.status()."""

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -366,6 +366,9 @@ def add_arguments(parser=None):
     ``--working-dir=...``:
         Propagate the working directory.
 
+    ``--access-policy=...``:
+        Set the Access Control policy.
+
     """
     if parser is None:
         parser = argparse.ArgumentParser()
@@ -388,6 +391,7 @@ def add_arguments(parser=None):
     group.add_argument('--registry-address', help="""Override the site default registry address.""")
     group.add_argument('--log-dir', help="""Set the logging directory.""")
     group.add_argument('--working-dir', help="""Propagate the working directory.""")
+    group.add_argument('--access-policy', help="""Set Access Control policy.""")
     return parser
 
 

--- a/ocs/testing.py
+++ b/ocs/testing.py
@@ -75,7 +75,7 @@ def create_agent_runner_fixture(agent_path, agent_name, args=None):
     return run_agent
 
 
-def create_client_fixture(instance_id, timeout=30):
+def create_client_fixture(instance_id, timeout=30, privs=None):
     """Create the fixture that provides tests a Client object.
 
     Parameters:
@@ -85,6 +85,7 @@ def create_client_fixture(instance_id, timeout=30):
             between attempts. This is useful if it takes some time for the
             Agent to start accepting connections, which varies depending on the
             Agent.
+        privs (str or int): privs argument for OCSClient constructor.
 
     """
     @pytest.fixture()
@@ -96,7 +97,7 @@ def create_client_fixture(instance_id, timeout=30):
 
         while attempts < timeout:
             try:
-                client = OCSClient(instance_id)
+                client = OCSClient(instance_id, privs=privs)
                 return client
             except RuntimeError as e:
                 print(f"Caught error: {e}")

--- a/tests/agents/util.py
+++ b/tests/agents/util.py
@@ -8,16 +8,19 @@ import txaio
 txaio.use_twisted()
 
 
-def create_agent_fixture(agent_class, agent_kwargs={}):
+def create_agent_fixture(agent_class, agent_kwargs={}, site_args={}):
     """Create a fixture for a given Agent."""
 
     @pytest.fixture
     def agent():
-        site_args = mock.MagicMock()
-        site_args.log_dir = '/tmp/'
-        site_args.access_policy = None
+        _site_args = mock.MagicMock()
+        _site_args.log_dir = '/tmp/'
+        _site_args.access_policy = None
+        for k, v in site_args.items():
+            setattr(_site_args, k, v)
+
         config = mock.MagicMock()
-        mock_agent = OCSAgent(config, site_args)
+        mock_agent = OCSAgent(config, _site_args)
 
         log = txaio.make_logger()
         txaio.start_logging(level='debug')

--- a/tests/agents/util.py
+++ b/tests/agents/util.py
@@ -15,6 +15,7 @@ def create_agent_fixture(agent_class, agent_kwargs={}):
     def agent():
         site_args = mock.MagicMock()
         site_args.log_dir = '/tmp/'
+        site_args.access_policy = None
         config = mock.MagicMock()
         mock_agent = OCSAgent(config, site_args)
 

--- a/tests/integration/test_access_integration.py
+++ b/tests/integration/test_access_integration.py
@@ -1,0 +1,36 @@
+import pytest
+
+import ocs
+from ocs.base import OpCode
+
+from ocs.testing import (
+    create_agent_runner_fixture,
+    create_client_fixture,
+)
+
+from integration.util import (
+    create_crossbar_fixture,
+)
+
+AGENT_PATH = '../ocs/agents/fake_data/agent.py'
+
+pytest_plugins = ("docker_compose")
+
+wait_for_crossbar = create_crossbar_fixture()
+run_agent = create_agent_runner_fixture(
+    AGENT_PATH, 'fake_data', ['--access-policy', 'override:a,b'])
+client_1 = create_client_fixture('fake-data-local')
+client_2 = create_client_fixture('fake-data-local', privs='a')
+
+
+@pytest.mark.integtest
+def test_fake_data_agent_delay_task(wait_for_crossbar, run_agent,
+                                    client_1, client_2):
+    # Without password, start should fail immediately.
+    resp = client_1.delay_task.start(delay=0.01)
+    assert resp.status == ocs.ERROR
+
+    # With password, should succeed.
+    resp = client_2.delay_task(delay=0.01)
+    assert resp.status == ocs.OK
+    assert resp.session['op_code'] == OpCode.SUCCEEDED.value

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -1,0 +1,90 @@
+import pytest
+import os
+import yaml
+
+from unittest import mock
+
+from ocs import access
+
+
+def test_access_enums():
+    """Instantiate and stringify all access enums."""
+    for i in [1,2,3]:
+        access.CredLevel(i).encode()
+        access.AccessLevel(i).encode()
+    for i in [0, 4]:
+        access.CredLevel(i).encode()
+        with pytest.raises(ValueError):
+            b = access.AccessLevel(i)
+
+    access.rejection_message(access.CredLevel(1),
+                             access.AccessLevel(2))
+
+
+def test_access_policy():
+    """Check that get_creds produces correct CredLevel for typical
+    policy requests.
+
+    """
+    rules = access.get_policy_default('director:')
+    assert access.get_creds('', rules).value == 1
+    assert access.get_creds('a', rules).value == 1
+
+    rules = access.get_policy_default('override:a,b')
+    assert access.get_creds('', rules).value == 1
+    assert access.get_creds('a', rules).value == 2
+    assert access.get_creds('b', rules).value == 3
+
+    with pytest.raises(ValueError):
+        rules = access.get_policy_default('invalid:')
+
+
+def test_access_hashfuncs():
+    """Check each hash function value stability."""
+    # hashfunc test cases
+    assert access.no_hash('a') == 'a'
+
+    # hashfunc mapping
+    bad_rules = {
+        'password-2': {
+            'hash': 'invalid',
+            'value': '0x0x',
+        }
+    }
+    assert access.get_creds('a', bad_rules).value == 1
+
+
+@pytest.fixture(scope='session')
+def password_file(tmp_path_factory):
+    """Write a password file."""
+    fn = tmp_path_factory.mktemp('ocs') / 'passwords.yaml'
+    yaml.dump([
+        {'agent-class': 'TestAgent',
+         'password-2': 'TA-two'},
+        {'instance-id': 'test-agent1',
+         'password-2': 'ta-two',
+         'password-3': 'ta-three'},
+        {'default': 'default',
+         'password-2': 'two'},
+    ], fn.open('w'))
+    return fn
+
+
+def test_access_get_client_password(password_file):
+    """Check that get_client_password parses the password_file data
+    appropriately.
+
+    """
+    with mock.patch('os.getenv', mock.Mock(return_value=str(password_file))):
+        # Fall through to default
+        assert access.get_client_password(2, 'A', 'I') == 'two'
+
+        # Agent / instance matching
+        assert access.get_client_password(2, 'TestAgent', 'test-agent1') == 'TA-two'
+        assert access.get_client_password(3, 'TestAgent', 'test-agent1') == 'ta-three'
+
+        # No-match
+        assert access.get_client_password(3, 'A', 'I') == ''
+
+        # Passing strings just returns the string
+        assert access.get_client_password('x', 'A', 'I') == 'x'

--- a/tests/test_ocs_agent.py
+++ b/tests/test_ocs_agent.py
@@ -51,6 +51,7 @@ def mock_agent():
     mock_config = MagicMock()
     mock_site_args = MagicMock()
     mock_site_args.log_dir = "./"
+    mock_site_args.access_policy = None
     a = OCSAgent(mock_config, mock_site_args, address='test.address')
     return a
 

--- a/tests/test_ocs_client.py
+++ b/tests/test_ocs_client.py
@@ -111,52 +111,52 @@ class TestGetOp:
     def test_task_abort(self, client_task):
         client, task = client_task
         print(task.abort())
-        client.request.assert_called_with('abort', 'task_name', credentials='')
+        client.request.assert_called_with('abort', 'task_name', password='')
 
     def test_task_start(self, client_task):
         client, task = client_task
         print(task.start())
         assert task.start.__doc__ == 'Example docstring'
         client.request.assert_called_with('start', 'task_name', params={},
-                                          credentials='')
+                                          password='')
 
     def test_task_wait(self, client_task):
         client, task = client_task
         print(task.wait())
         client.request.assert_called_with('wait', 'task_name', timeout=None,
-                                          credentials='')
+                                          password='')
 
     def test_task_status(self, client_task):
         client, task = client_task
         print(task.status())
         client.request.assert_called_with('status', 'task_name',
-                                          credentials='')
+                                          password='')
 
     def test_task_call(self):
         client, task = self._client_operation('task', 'task_name', ocs.OK)
         print(task())
         # equivalent to 'start' + 'wait', but we can only check the last call
         client.request.assert_called_with('wait', 'task_name', timeout=None,
-                                          credentials='')
+                                          password='')
 
     def test_task_call_w_error(self):
         client, task = self._client_operation('task', 'task_name', ocs.ERROR)
         print(task())
         # error skips the 'wait' call after 'start'
         client.request.assert_called_with('start', 'task_name', params={},
-                                          credentials='')
+                                          password='')
 
     def test_process_stop(self, client_process):
         client, process = client_process
         print(process.stop())
         client.request.assert_called_with('stop', 'process_name',
-                                          credentials='')
+                                          password='')
 
     def test_process_call(self, client_process):
         client, process = client_process
         print(process())
         client.request.assert_called_with('status', 'process_name',
-                                          credentials='')
+                                          password='')
 
 
 class TestOCSClient:

--- a/tests/test_ocs_client.py
+++ b/tests/test_ocs_client.py
@@ -65,7 +65,7 @@ def test_opname_to_attr(input_, expected):
 class TestGetOp:
     def test_invalid_op_type(self):
         with pytest.raises(ValueError):
-            _get_op('not_valid', 'name', MagicMock(), MagicMock())
+            _get_op('not_valid', 'name', MagicMock(), MagicMock(), '')
 
     def mock_client(self, session_name, response_code):
         """Mock a ControlClient object that has a predefined request response for
@@ -96,7 +96,7 @@ class TestGetOp:
         client = self.mock_client(op_name, response_code)
         encoded_task = {'blocking': True,
                         'docstring': 'Example docstring'}
-        task = _get_op(op_type, op_name, encoded_task, client)
+        task = _get_op(op_type, op_name, encoded_task, client, '')
 
         return (client, task)
 
@@ -111,45 +111,52 @@ class TestGetOp:
     def test_task_abort(self, client_task):
         client, task = client_task
         print(task.abort())
-        client.request.assert_called_with('abort', 'task_name')
+        client.request.assert_called_with('abort', 'task_name', credentials='')
 
     def test_task_start(self, client_task):
         client, task = client_task
         print(task.start())
         assert task.start.__doc__ == 'Example docstring'
-        client.request.assert_called_with('start', 'task_name', params={})
+        client.request.assert_called_with('start', 'task_name', params={},
+                                          credentials='')
 
     def test_task_wait(self, client_task):
         client, task = client_task
         print(task.wait())
-        client.request.assert_called_with('wait', 'task_name', timeout=None)
+        client.request.assert_called_with('wait', 'task_name', timeout=None,
+                                          credentials='')
 
     def test_task_status(self, client_task):
         client, task = client_task
         print(task.status())
-        client.request.assert_called_with('status', 'task_name')
+        client.request.assert_called_with('status', 'task_name',
+                                          credentials='')
 
     def test_task_call(self):
         client, task = self._client_operation('task', 'task_name', ocs.OK)
         print(task())
         # equivalent to 'start' + 'wait', but we can only check the last call
-        client.request.assert_called_with('wait', 'task_name', timeout=None)
+        client.request.assert_called_with('wait', 'task_name', timeout=None,
+                                          credentials='')
 
     def test_task_call_w_error(self):
         client, task = self._client_operation('task', 'task_name', ocs.ERROR)
         print(task())
         # error skips the 'wait' call after 'start'
-        client.request.assert_called_with('start', 'task_name', params={})
+        client.request.assert_called_with('start', 'task_name', params={},
+                                          credentials='')
 
     def test_process_stop(self, client_process):
         client, process = client_process
         print(process.stop())
-        client.request.assert_called_with('stop', 'process_name')
+        client.request.assert_called_with('stop', 'process_name',
+                                          credentials='')
 
     def test_process_call(self, client_process):
         client, process = client_process
         print(process())
-        client.request.assert_called_with('status', 'process_name')
+        client.request.assert_called_with('status', 'process_name',
+                                          credentials='')
 
 
 class TestOCSClient:


### PR DESCRIPTION
Draft for inspection.  Right now you can:
- Change agents to require different access levels (1,2,3) for a each op.
- Specify the level2 and level3 access passwords as cmdline args to the instance.
- Pass passwords through manually from clients (as in c1 below).
- Have clients try to figure out what password to use based on a password config file and a requested access level (as in c2 below).

To demo, set up FakeDataAgent with additional argument:
```
    'arguments': [['--access-policy', 'override:fake-pw-2,fake-pw-3']]},
```

Consider these clients:
```
  c0 = ocs_client.OCSClient('faker4')
  c1 = ocs_client.OCSClient('faker4', privs='fake-pw-2')
  c2 = ocs_client.OCSClient('faker4', privs=2)
```

Try to start or stop delay_task on each ... :
```
   r = c.delay_task.start(delay=1)
```

The c0 should fail; c1 should work; c2 will raise an error because it can't find your ~/ocs-passwords.yaml file.  Create it with just this inside:
```
- agent-class: FakeDataAgent
  password-2: fake-pw-2
```
It doesn't have to be at ~/ocs-passwords.yaml ... override with envvar OCS_PASSWORDS_FILE=whatever.yaml
