### PR TITLE
ocs-agent-cli renames itself in process list

### DIFF
--- a/ocs/agent_cli.py
+++ b/ocs/agent_cli.py
@@ -1,6 +1,7 @@
 import argparse
 import importlib
 import os
+import setproctitle
 import sys
 import warnings
 
@@ -181,6 +182,10 @@ def main(args=None):
         entrypoint = agent_info.get("entry_point", "main")
 
         mod = importlib.import_module(_module)
+
+        title = f'ocs-agent:{instance.data["instance-id"]}'
+        print(f'Renaming this process to: "{title}"')
+        setproctitle.setproctitle(title)
 
     start = getattr(mod, entrypoint)  # This is the start function.
     start(args=post_args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ twisted
 deprecation
 PyYAML
 importlib_metadata
+setproctitle
 
 # InfluxDB Publisher
 influxdb

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(name='ocs',
           'influxdb',
           'numpy',
           'importlib_metadata;python_version<"3.10"',
+          'setproctitle',
       ],
       extras_require={
           "so3g": ["so3g"],


### PR DESCRIPTION
Instead of showing up in top as "ocs-agent-cli", it shows up as "ocs-agent:{instance_id}".

This is a minor quality of life improvement ... sometimes you need to kill a process, or see who's using all the memory / CPU, and it's not obvious if all agents launched through ocs-agent-cli simply report themselves as "ocs-agent-cli".
