### PR TITLE
Revist address_root != "observatory"

### DIFF
--- a/docker/crossbar/Dockerfile
+++ b/docker/crossbar/Dockerfile
@@ -8,8 +8,11 @@ FROM crossbario/crossbar:cpy3-20.8.1
 # Run as root to put config in place and chown
 USER root
 
-# Copy in config and requirements files
-COPY config.json /ocs/.crossbar/config.json
+# Copy in config template and wrapper script
+COPY run-crossbar.sh /ocs/run-crossbar.sh
+RUN chmod a+x /ocs/run-crossbar.sh
+
+COPY config.json.template /ocs/.crossbar/config-with-address.json.template
 RUN chown -R crossbar:crossbar /ocs
 
 # Run image as crossbar user during normal operation
@@ -20,4 +23,4 @@ EXPOSE 8001
 
 # Run crossbar when the container launches
 # User made config.json should be mounted to /ocs/.crossbar/config.json
-ENTRYPOINT ["crossbar", "start", "--cbdir", "/ocs/.crossbar"]
+ENTRYPOINT ["/ocs/run-crossbar.sh"]

--- a/docker/crossbar/config.json.template
+++ b/docker/crossbar/config.json.template
@@ -10,13 +10,13 @@
             },
             "realms": [
                 {
-                    "name": "test_realm",
+                    "name": "{realm}",
                     "roles": [
                         {
                             "name": "iocs_agent",
                             "permissions": [
                                 {
-                                    "uri": "observatory.",
+                                    "uri": "{address_root}.",
                                     "match": "prefix",
                                     "allow": {
                                         "call": true,
@@ -36,7 +36,7 @@
                             "name": "iocs_controller",
                             "permissions": [
                                 {
-                                    "uri": "observatory.",
+                                    "uri": "{address_root}.",
                                     "match": "prefix",
                                     "allow": {
                                         "call": true,
@@ -60,7 +60,7 @@
 		    "type": "web",
                     "endpoint": {
                         "type": "tcp",
-                        "port": 8001
+                        "port": {port}
                     },
 		    "paths": {
 			"ws": {
@@ -81,7 +81,7 @@
 			},
 			"call": {
 			    "type": "caller",
-			    "realm": "test_realm",
+			    "realm": "{realm}",
 			    "role": "iocs_controller",
 			    "options": {
 				}

--- a/docker/crossbar/run-crossbar.sh
+++ b/docker/crossbar/run-crossbar.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+CONFIG_DIR=/ocs/.crossbar
+OCS_ADDRESS_ROOT=${OCS_ADDRESS_ROOT:-observatory}
+OCS_CROSSBAR_REALM=${OCS_REALM:-test_realm}
+OCS_CROSSBAR_PORT=${OCS_PORT:-8001}
+
+# Did user mount in a config.json?
+if [ -e $CONFIG_DIR/config.json ]; then
+    echo Launching user-provided config.json
+    CONFIG_FILE=$CONFIG_DIR/config.json
+else
+    pattern="
+        s/{address_root}/${OCS_ADDRESS_ROOT}/g
+        s/{realm}/${OCS_CROSSBAR_REALM}/g
+        s/{port}/${OCS_CROSSBAR_PORT}/g
+        "
+    echo "Processing template with replacements:"
+    echo "$pattern"
+    echo
+
+    CONFIG_FILE=$CONFIG_DIR/config-with-address.json
+    sed "$pattern" \
+        $CONFIG_DIR/config-with-address.json.template \
+        > $CONFIG_FILE
+fi
+
+crossbar start --cbdir $CONFIG_DIR --config $CONFIG_FILE

--- a/docs/agents/aggregator.rst
+++ b/docs/agents/aggregator.rst
@@ -90,7 +90,9 @@ to register a feed so that it will be recorded by the aggregator.
 Unregistered providers will automatically be added when they send data,
 and stale providers will be removed if no data is received in a specified
 time period.
-To do this, the aggregator monitors all feeds in the ``observatory`` namespace to find
+
+To do this, the aggregator monitors all feeds in the namespace defined
+by the `{address_root}` prefix to find
 feeds that should be recorded.  If the aggregator receives data from a feed
 registered with ``record=True``, it will automatically add that feed as a
 Provider, and will start putting incoming data into frames every ``frame_length``

--- a/docs/developer/writing_an_agent/docker.rst
+++ b/docs/developer/writing_an_agent/docker.rst
@@ -84,7 +84,6 @@ the BarbonesAgent config to the ``ocs-docker`` host.:
       wamp_http: http://localhost:8001/call
       wamp_realm: test_realm
       address_root: observatory
-      registry_address: observatory.registry
 
     hosts:
 

--- a/docs/user/crossbar_config.rst
+++ b/docs/user/crossbar_config.rst
@@ -80,22 +80,46 @@ Running with Docker
 We recommend running crossbar within a Docker container. We build the
 ``simonsobs/ocs-crossbar`` container from the official `crossbar.io Docker
 image`_, specifically the cpy3 version. Bundled within the container is a
-simple OCS configuration that should work with the configuration
-recommendations in this documentation.
+simple crossbar configuration file template with defaults that are
+compatible with examples in this documentation.
 
-If changes need to be made, then you will need to generate your own
-configuration file as described above. To use a modified configuration in the
-container you can either:
+To adjust the crossbar configuration in the container, you can either:
 
-- Edit the default configuration file and rebuild the Docker image
+- Edit the default configuration file template and rebuild the Docker image
+- Use environment variables to alter the most basic settings
 - Mount the new configuration file over ``/ocs/.crossbar/config.json`` with the
   proper permissions
 
 .. _`crossbar.io Docker image`: https://hub.docker.com/r/crossbario/crossbar
 
+Environment variables in ocs-crossbar
+-------------------------------------
+The following environment variables can be set, to affect the
+generation of the crossbar configuration file when the container
+starts up:
+
+- OCS_ADDRESS_ROOT (default "observatory"): the base URI for OCS
+  entities (this needs to match the `address_root` set in the SCF).
+- OCS_CROSSBAR_REALM (default "test_realm"): the WAMP realm to
+  configure for OCS.
+- OCS_CROSSBAR_PORT (default 8001): the port on which crossbar will
+  accept requests.
+
+Here is an example of a docker-compose entry that overrides the
+OCS_ADDRESS_ROOT::
+
+      crossbar:
+        image: simonsobs/ocs-crossbar:latest
+        ports:
+          - "127.0.0.1:8001:8001" # expose for OCS
+        environment:
+          - PYTHONUNBUFFERED=1
+          - OCS_ADDRESS_ROOT=laboratory
+
 Rebuilding the Docker Image
 ---------------------------
-To rebuild the Docker image after modifying ``ocs/docker/config.json`` run::
+To rebuild the Docker image after modifying
+``ocs/docker/config.json.template`` run::
 
     $ docker build -t ocs-crossbar .
 
@@ -104,7 +128,7 @@ You should then update your configuration to use the new, local,
 
 Bind Mounting the Configuration
 -------------------------------
-To instead mount the new configuration into the pre-built image, first chown
+To instead mount a new configuration into the pre-built image, first chown
 your file to be owned by user and group 242 (the default crossbar UID/GID),
 then mount it appropriately in your docker-compose file. Here we assume you
 put the configuration in the directory ``./dot_crossbar/``::
@@ -114,10 +138,10 @@ put the configuration in the directory ``./dot_crossbar/``::
 Your docker-compose service should then be configured like::
 
     crossbar:
-    image: simonsobs/ocs-crossbar
-    ports:
-      - "8001:8001" # expose for OCS
-    volumes:
-      - ./dot_crossbar:/ocs/.crossbar
-    environment:
-         - PYTHONUNBUFFERED=1
+      image: simonsobs/ocs-crossbar
+      ports:
+        - "8001:8001" # expose for OCS
+      volumes:
+        - ./dot_crossbar:/ocs/.crossbar
+      environment:
+           - PYTHONUNBUFFERED=1

--- a/docs/user/crossbar_config.rst
+++ b/docs/user/crossbar_config.rst
@@ -36,8 +36,9 @@ Configuration`_ page.
 
 Generating a New Config File
 ----------------------------
-``ocsbow`` can be used to generate a default configuration file, based on
-options in your OSC file, which can then be modified if needed.
+``ocs-local-support`` can be used to generate a default configuration
+file, based on options in your SCF, which can then be modified if
+needed.
 
 First, we make sure our ``OCS_CONFIG_DIR`` environment variable is set::
 
@@ -53,7 +54,7 @@ that)::
 This directory needs to be configured as your crossbar 'config-dir' in your
 ocs-site-config file. Now we can generate the config::
 
-    $ ocsbow crossbar generate_config
+    $ ocs-local-support generate_crossbar_config
     The crossbar config-dir is set to:
       ./dot_crossbar/
     Using
@@ -68,9 +69,10 @@ modifications needed for your deployment.
 
 .. note::
 
-    The crossbar 'config-dir' block and the 'agent-instance' block defining the
-    'HostManager' Agent are both required for the system you are running ocsbow
-    on. Be sure to add these to your SCF if they do not exist.
+    The crossbar 'config-dir' block and the 'agent-instance' block
+    defining the 'HostManager' Agent are both required for the system
+    you are running `ocs-local-support` on. Be sure to add these to
+    your SCF if they do not exist.
 
 Running with Docker
 ===================

--- a/docs/user/crossbar_config.rst
+++ b/docs/user/crossbar_config.rst
@@ -12,67 +12,30 @@ the interface to the crossbar server.
 
 .. note::
 
-    For most test deployments of OCS, you should not need to modify this file
-    and can use the one that comes with the ``simonsobs/ocs-crossbar`` Docker
-    Image.
+    For most simple lab deployments of OCS, you should not need to modify this
+    file and can use the one that comes with the ``simonsobs/ocs-crossbar``
+    Docker Image.
 
-Example Config
---------------
-An example of the default OCS crossbar config that is bundled into
-``simonsobs/ocs-crossbar`` can be found in the repository at
-`ocs/docker/crossbar/config.json`_. This is based on the template in
-`ocs/ocs/support/crossbar_config.json`_.
+Configuration File Template
+---------------------------
+The template that the default OCS crossbar config is built with is shown here:
 
-The unique parts of this to OCS are the realm name, "test_realm", defined
-roles of "iocs_agent" and "iocs_controller, and "address_root" of
-"observatory.". Additionally, we run on port 8001.
+.. literalinclude:: ../../docker/crossbar/config.json.template
+
+The variables `realm`, `address_root`, and `port` are all configurable and must
+match configuration options set in your SCF. Keep reading this page to see how
+to configure these variables.
+
+.. note::
+    Changing the `address_root` has implications for the how your data is
+    stored and accessed in tools such as Grafana. It is recommended you pick
+    something reasonable when you first configure your system and do not change it
+    later.
 
 For further details on crossbar server configuration, see the crossbar `Router
 Configuration`_ page.
 
-.. _`ocs/docker/crossbar/config.json`: https://github.com/simonsobs/ocs/blob/main/docker/crossbar/config.json
-.. _`ocs/ocs/support/crossbar_config.json`: https://github.com/simonsobs/ocs/blob/main/ocs/support/crossbar_config.json
 .. _`Router Configuration`: https://crossbar.io/docs/Router-Configuration/
-
-Generating a New Config File
-----------------------------
-``ocs-local-support`` can be used to generate a default configuration
-file, based on options in your SCF, which can then be modified if
-needed.
-
-First, we make sure our ``OCS_CONFIG_DIR`` environment variable is set::
-
-    $ cd ocs-site-configs/
-    $ export OCS_CONFIG_DIR=`pwd`
-
-We should make a directory for the crossbar config, let's call it
-``dot_crossbar/`` (typically a dot directory, but for visibility we'll avoid
-that)::
-
-    $ mkdir -p ocs-site-configs/dot_crossbar/
-
-This directory needs to be configured as your crossbar 'config-dir' in your
-ocs-site-config file. Now we can generate the config::
-
-    $ ocs-local-support generate_crossbar_config
-    The crossbar config-dir is set to:
-      ./dot_crossbar/
-    Using
-      ./dot_crossbar/config.json
-    as the target output file.
-
-    Generating crossbar config text.
-    Wrote ./dot_crossbar/config.json
-
-You should now see a crossbar config file in ``./dot_crossbar/``. Make any
-modifications needed for your deployment.
-
-.. note::
-
-    The crossbar 'config-dir' block and the 'agent-instance' block
-    defining the 'HostManager' Agent are both required for the system
-    you are running `ocs-local-support` on. Be sure to add these to
-    your SCF if they do not exist.
 
 Running with Docker
 ===================
@@ -85,10 +48,9 @@ compatible with examples in this documentation.
 
 To adjust the crossbar configuration in the container, you can either:
 
-- Edit the default configuration file template and rebuild the Docker image
 - Use environment variables to alter the most basic settings
-- Mount the new configuration file over ``/ocs/.crossbar/config.json`` with the
-  proper permissions
+- Generate and mount a new configuration file over
+  ``/ocs/.crossbar/config.json`` with the proper permissions
 
 .. _`crossbar.io Docker image`: https://hub.docker.com/r/crossbario/crossbar
 
@@ -116,16 +78,6 @@ OCS_ADDRESS_ROOT::
           - PYTHONUNBUFFERED=1
           - OCS_ADDRESS_ROOT=laboratory
 
-Rebuilding the Docker Image
----------------------------
-To rebuild the Docker image after modifying
-``ocs/docker/config.json.template`` run::
-
-    $ docker build -t ocs-crossbar .
-
-You should then update your configuration to use the new, local,
-``ocs-crossbar`` image.
-
 Bind Mounting the Configuration
 -------------------------------
 To instead mount a new configuration into the pre-built image, first chown
@@ -134,6 +86,10 @@ then mount it appropriately in your docker-compose file. Here we assume you
 put the configuration in the directory ``./dot_crossbar/``::
 
     $ chown -R 242:242 dot_crossbar/
+
+.. note::
+    If you do not already have a configuration file to modify and use, see the
+    next section on generating one.
 
 Your docker-compose service should then be configured like::
 
@@ -144,4 +100,45 @@ Your docker-compose service should then be configured like::
       volumes:
         - ./dot_crossbar:/ocs/.crossbar
       environment:
-           - PYTHONUNBUFFERED=1
+        - PYTHONUNBUFFERED=1
+
+Generating a New Config File
+----------------------------
+``ocs-local-support`` can be used to generate a default configuration
+file, based on options in your SCF, which can then be modified if
+needed.
+
+First, we make sure our ``OCS_CONFIG_DIR`` environment variable is set::
+
+    $ cd ocs-site-configs/
+    $ export OCS_CONFIG_DIR=`pwd`
+
+We should make a directory for the crossbar config, following along above let's
+call it ``dot_crossbar/`` (typically a dot directory, but for visibility we'll
+avoid that)::
+
+    $ mkdir -p ocs-site-configs/dot_crossbar/
+
+This directory needs to be configured as your crossbar 'config-dir' in your
+ocs-site-config file. (See example in :ref:`site_config_user`.) Now we can
+generate the config::
+
+    $ ocs-local-support generate_crossbar_config
+    The crossbar config-dir is set to:
+      ./dot_crossbar/
+    Using
+      ./dot_crossbar/config.json
+    as the target output file.
+
+    Generating crossbar config text.
+    Wrote ./dot_crossbar/config.json
+
+You should now see a crossbar config file in ``./dot_crossbar/``. Make any
+modifications needed for your deployment.
+
+.. note::
+
+    The crossbar 'config-dir' block and the 'agent-instance' block
+    defining the 'HostManager' Agent are both required for the system
+    you are running `ocs-local-support` on. Be sure to add these to
+    your SCF if they do not exist.

--- a/docs/user/docker_config.rst
+++ b/docs/user/docker_config.rst
@@ -61,7 +61,7 @@ components)::
         ports:
           - "127.0.0.1:8001:8001" # expose for OCS
         environment:
-             - PYTHONUNBUFFERED=1
+          - PYTHONUNBUFFERED=1
 
       # --------------------------------------------------------------------------
       # OCS Agents
@@ -242,7 +242,7 @@ Where the separate compose files would look something like::
         ports:
           - "127.0.0.1:8001:8001" # expose for OCS
         environment:
-             - PYTHONUNBUFFERED=1
+          - PYTHONUNBUFFERED=1
 
 ::
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -48,7 +48,6 @@ structure.
       wamp_http: http://localhost:8001/call
       wamp_realm: test_realm
       address_root: observatory
-      registry_address: observatory.registry
 
     hosts:
 

--- a/docs/user/site_config.rst
+++ b/docs/user/site_config.rst
@@ -120,6 +120,13 @@ and feed addresses on the crossbar network.  While "observatory" is
 the default, it can be changed as long as the crossbar configuration
 is also updated to permit operations on the `{address_root}.` uri.
 
+.. note::
+   The hub settings must match the crossbar configuration.  If you
+   change `wamp_realm` or `address_root`, especially, be sure to
+   update your crossbar configuration accordingly.  (If using the
+   ocs-crossbar docker image, this can be done through environment
+   variables in the docker-compose.yaml file.)
+
 Under `hosts` we have defined a three hosts, `host-1`, `host-1-docker`, and
 `host-2`. This configuration example shows a mix of Agents running directly on
 hosts and running within Docker containers.

--- a/docs/user/site_config.rst
+++ b/docs/user/site_config.rst
@@ -120,12 +120,12 @@ and feed addresses on the crossbar network.  While "observatory" is
 the default, it can be changed as long as the crossbar configuration
 is also updated to permit operations on the `{address_root}.` uri.
 
-.. note::
+.. warning::
    The hub settings must match the crossbar configuration.  If you
    change `wamp_realm` or `address_root`, especially, be sure to
    update your crossbar configuration accordingly.  (If using the
    ocs-crossbar docker image, this can be done through environment
-   variables in the docker-compose.yaml file.)
+   variables in the ``docker-compose.yaml`` file.)
 
 Under `hosts` we have defined a three hosts, `host-1`, `host-1-docker`, and
 `host-2`. This configuration example shows a mix of Agents running directly on

--- a/docs/user/site_config.rst
+++ b/docs/user/site_config.rst
@@ -35,7 +35,6 @@ instances (running two different classes of agent):
     wamp_http: http://10.10.10.3:8001/call
     wamp_realm: test_realm
     address_root: observatory
-    registry_agent: observatory.registry
 
   hosts:
 

--- a/docs/user/site_config.rst
+++ b/docs/user/site_config.rst
@@ -116,6 +116,11 @@ The `hub` section defines the connection parameters for the crossbar server.
 This entire section will likely remain unchanged, except for the
 ``wamp_server`` and ``wamp_http`` IP addresses.
 
+The `address_root` setting determines the leading token in all agent
+and feed addresses on the crossbar network.  While "observatory" is
+the default, it can be changed as long as the crossbar configuration
+is also updated to permit operations on the `{address_root}.` uri.
+
 Under `hosts` we have defined a three hosts, `host-1`, `host-1-docker`, and
 `host-2`. This configuration example shows a mix of Agents running directly on
 hosts and running within Docker containers.

--- a/example/miniobs/default.yaml
+++ b/example/miniobs/default.yaml
@@ -5,7 +5,6 @@ hub:
   wamp_http: http://localhost:8001/call
   wamp_realm: test_realm
   address_root: observatory
-  registry_address: observatory.registry
 
 hosts:
 

--- a/ocs/agents/aggregator/agent.py
+++ b/ocs/agents/aggregator/agent.py
@@ -57,7 +57,7 @@ class AggregatorAgent:
         # If this ends up being too much data, we can add a tag '.record'
         # at the end of the address of recorded feeds, and filter by that.
         self.agent.subscribe_on_start(self._enqueue_incoming_data,
-                                      'observatory..feeds.',
+                                      f'{args.address_root}..feeds.',
                                       options={'match': 'wildcard'})
 
         record_on_start = (args.initial_state == 'record')

--- a/ocs/agents/host_manager/agent.py
+++ b/ocs/agents/host_manager/agent.py
@@ -601,9 +601,6 @@ def main(args=None):
             os.dup2(null, stream.fileno())
         os.close(null)
 
-    # To reduce "try again" noise, don't tell Registry about HostManager.
-    args.registry_address = 'none'
-
     agent, runner = ocs_agent.init_site_agent(args)
 
     docker_composes = []

--- a/ocs/agents/influxdb_publisher/agent.py
+++ b/ocs/agents/influxdb_publisher/agent.py
@@ -97,6 +97,7 @@ class InfluxDBAgent:
                               port=self.args.port,
                               protocol=self.args.protocol,
                               gzip=self.args.gzip,
+                              operate_callback=lambda: self.aggregate,
                               )
 
         session.set_status('running')

--- a/ocs/agents/influxdb_publisher/agent.py
+++ b/ocs/agents/influxdb_publisher/agent.py
@@ -50,7 +50,7 @@ class InfluxDBAgent:
         self.loop_time = 1
 
         self.agent.subscribe_on_start(self._enqueue_incoming_data,
-                                      'observatory..feeds.',
+                                      f'{args.address_root}..feeds.',
                                       options={'match': 'wildcard'})
 
         record_on_start = (args.initial_state == 'record')

--- a/ocs/agents/registry/agent.py
+++ b/ocs/agents/registry/agent.py
@@ -98,7 +98,7 @@ class Registry:
         self.agent_timeout = 5.0  # Removes agent after 5 seconds of no heartbeat.
 
         self.agent.subscribe_on_start(
-            self._register_heartbeat, 'observatory..feeds.heartbeat',
+            self._register_heartbeat, f'{args.address_root}..feeds.heartbeat',
             options={'match': 'wildcard'}
         )
 

--- a/ocs/checkdata.py
+++ b/ocs/checkdata.py
@@ -108,11 +108,11 @@ class DataChecker:
             {FEED1:
                 {"fields":
                    {FIELD1:
-                       {'full_name': 'observatory.INSTANCE_ID.feeds.FEED.FIELD',
+                       {'full_name': 'ADDRESS_ROOT.INSTANCE_ID.feeds.FEED.FIELD',
                         't_last': float,
                         'v_last': float},
                     FIELD2:
-                       {'full_name': 'observatory.INSTANCE_ID.feeds.FEED.FIELD',
+                       {'full_name': 'ADDRESS_ROOT.INSTANCE_ID.feeds.FEED.FIELD',
                         't_last': float,
                         'v_last': float}
                     },

--- a/ocs/client_cli.py
+++ b/ocs/client_cli.py
@@ -62,8 +62,7 @@ def get_parser():
     # scan
     p = client_sp.add_parser('scan', help="Gather and print list of Agents.")
     p.add_argument('--details', action='store_true', help="List all Operations with their current status OpCode.")
-    p.add_argument('--use-registry', nargs='?', const='registry', help=
-                   "Query the registry (faster than listening for heartbeats). "
+    p.add_argument('--use-registry', nargs='?', const='registry', help="Query the registry (faster than listening for heartbeats). "
                    "Pass the registry instance_id as an argument (default to 'registry').")
 
     # scan

--- a/ocs/client_cli.py
+++ b/ocs/client_cli.py
@@ -62,7 +62,9 @@ def get_parser():
     # scan
     p = client_sp.add_parser('scan', help="Gather and print list of Agents.")
     p.add_argument('--details', action='store_true', help="List all Operations with their current status OpCode.")
-    p.add_argument('--use-registry', action='store_true', help="Query the registry (faster than listening for heartbeats).")
+    p.add_argument('--use-registry', nargs='?', const='registry', help=
+                   "Query the registry (faster than listening for heartbeats). "
+                   "Pass the registry instance_id as an argument (default to 'registry').")
 
     # scan
     p = client_sp.add_parser('listen', help="Subscribe to feed(s) and dump to stdout.")
@@ -122,9 +124,7 @@ def scan(parser, args):
         parser.error('Unable to find the OCS config; set OCS_CONFIG_DIR?')
 
     if args.use_registry:
-        reg_addr = args.registry_address
-        if reg_addr is None:
-            reg_addr = 'registry'
+        reg_addr = f'{args.address_root}.{args.use_registry}'
         try:
             c = OCSClient(get_instance_id(reg_addr, args), args=args)
         except RuntimeError as e:

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -171,9 +171,16 @@ class OCSAgent(ApplicationSession):
         try:
             yield self.register(self._ops_handler, self.agent_address + '.ops')
             yield self.register(self._management_handler, self.agent_address)
-        except ApplicationError:
-            self.log.error('Failed to register basic handlers @ %s; '
-                           'agent probably running already.' % self.agent_address)
+        except ApplicationError as e:
+            self.log.error('Failed to register basic handlers!  '
+                           'Error: {error}', error=e)
+            if e.error == 'wamp.error.not_authorized':
+                self.log.error('Are the WAMP realm and OCS address_root consistent '
+                               'in OCS site config and crossbar config.json?')
+            elif e.error == 'wamp.error.procedure_already_exists':
+                self.log.error('Is this agent already running? '
+                               'agent_address="{agent_address}"',
+                               agent_address=self.agent_address)
             self.leave()
             return
 

--- a/ocs/ocsbow.py
+++ b/ocs/ocsbow.py
@@ -415,9 +415,11 @@ def generate_crossbar_config(cm, site_config):
                 print(line, end='')
             print('\n')
             print('To adopt the new config, remove %s and re-run me.' % cb_filename)
+        print()
     else:
         open(cb_filename, 'w').write(config_text)
         print('Wrote %s' % cb_filename)
+        print()
 
 
 class CrossbarManager:
@@ -805,6 +807,15 @@ class LocalSupports:
                                   'running, but should start if you run "ocs-local-support start".'))
         self.analysis = solutions
 
+    def fail_on_missing_crossbar_config(self):
+        """Check if crossbar is managed by this config.  If not, print
+        error message and exit(1)."""
+        if not self.crossbar['manage']:
+            print('Error!  Crossbar config file not set.\n\n'
+                  'To start crossbar or to generate a config file, the site '
+                  'config file must have a "crossbar" entry; see docs.\n')
+            sys.exit(1)
+
 
 def main(args=None):
     args, site_config = get_args_and_site_config(args)
@@ -969,8 +980,10 @@ def main_local(args=None):
                 print('Trouble!')
                 for text in fatals:
                     print(_term_format(text, '    ', 4))
+                sys.exit(1)
 
             if any([soln == 'crossbar' for soln, text in supports.analysis]):
+                supports.fail_on_missing_crossbar_config()
                 print('Trying to start crossbar...')
                 supports.crossbar['ctrl'].action('start', foreground=args.foreground)
                 supports.update()  # refresh .analysis
@@ -1011,5 +1024,6 @@ def main_local(args=None):
                     print('No running crossbar detected, system is already "down".')
 
         elif action == 'generate_crossbar_config':
+            supports.fail_on_missing_crossbar_config()
             cm = supports.crossbar['ctrl']
             generate_crossbar_config(cm, site_config)

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -190,10 +190,6 @@ class HubConfig:
             ``observatory`` or ``detlab``.  (Command line override:
             ``--address-root``.)
 
-        ``registry_address`` (optional): The address of the OCS Registry
-            Agent.  See :ref:`registry`.  (Command line override:
-            ``--registry-address``.)
-
         """
         self = cls()
         self.parent = parent
@@ -385,7 +381,7 @@ def add_arguments(parser=None):
     group.add_argument('--instance-id', help="""Look in the SCF for Agent-instance specific configuration options,
        and use those to launch the Agent.""")
     group.add_argument('--address-root', help="""Override the site default address root.""")
-    group.add_argument('--registry-address', help="""Override the site default registry address.""")
+    group.add_argument('--registry-address', help="""Deprecated.""")
     group.add_argument('--log-dir', help="""Set the logging directory.""")
     group.add_argument('--working-dir', help="""Propagate the working directory.""")
     return parser
@@ -466,9 +462,6 @@ def get_config(args, agent_class=None):
     if args.site_realm is not None:
         site_config.hub.data['wamp_realm'] = args.site_realm
 
-    if args.registry_address is not None:
-        site_config.hub.data['registry_address'] = args.registry_address
-
     # Identify our agent-instance.
     instance_config = None
     if no_dev_match:
@@ -515,8 +508,6 @@ def add_site_attributes(args, site, host=None):
         args.site_realm = site.hub.data['wamp_realm']
     if args.address_root is None:
         args.address_root = site.hub.data['address_root']
-    if args.registry_address is None:
-        args.registry_address = site.hub.data.get('registry_address')
     if (args.log_dir is None) and (host is not None):
         args.log_dir = host.log_dir
 

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -187,8 +187,8 @@ class HubConfig:
 
         ``address_root`` (required): The base address to be used by
             all OCS Agents.  This is normally something simple like
-            ``observatory`` or ``detlab.system1``.  (Command line
-            override: ``--address-root``.)
+            ``observatory`` or ``detlab``.  (Command line override:
+            ``--address-root``.)
 
         ``registry_address`` (optional): The address of the OCS Registry
             Agent.  See :ref:`registry`.  (Command line override:

--- a/tests/agents/test_registry_agent.py
+++ b/tests/agents/test_registry_agent.py
@@ -4,8 +4,10 @@ import pytest_twisted
 from agents.util import create_session, create_agent_fixture
 
 from ocs.agents.registry.agent import RegisteredAgent, Registry, make_parser
+from ocs import site_config
 
 parser = make_parser()
+site_config.add_arguments(parser)
 args = parser.parse_args(['--wait-time', '0.1'])
 agent = create_agent_fixture(Registry, agent_kwargs=dict(args=args))
 

--- a/tests/default.yaml
+++ b/tests/default.yaml
@@ -5,7 +5,6 @@ hub:
   wamp_http: http://127.0.0.1:18001/call
   wamp_realm: test_realm
   address_root: observatory
-  registry_address: observatory.registry
 
 hosts:
 

--- a/tests/test_site_config.py
+++ b/tests/test_site_config.py
@@ -28,8 +28,7 @@ class TestGetControlClient:
         mock_site = MagicMock()
         mock_site.hub.data = {'wamp_http': 'http://127.0.0.1:8001',
                               'wamp_realm': 'test_realm',
-                              'address_root': 'observatory',
-                              'registry_address': 'observatory.registry'}
+                              'address_root': 'observatory'}
 
         get_control_client('test', site=mock_site, client_type=None)
 
@@ -40,8 +39,7 @@ class TestGetControlClient:
         """
         mock_site = MagicMock()
         mock_site.hub.data = {'wamp_realm': 'test_realm',
-                              'address_root': 'observatory',
-                              'registry_address': 'observatory.registry'}
+                              'address_root': 'observatory'}
 
         with pytest.raises(ValueError):
             get_control_client('test', site=mock_site, client_type=None)


### PR DESCRIPTION
## Description

The `address_root` has always been set to `observatory` in OCS installations.  But this prefix is configurable in the SCF, and for the most part wasn't hard-coded anywhere in ocs (nor socs).

I have removed a small number of hard-coded occurrences of `observatory.`.  These were in the feed subscription wildcards the registry, aggregator and influxdbpublisher.

The address_root was intended to be user configurable; I consider this to be a bugfix.

Some additional changes along the way:
- I have purged references to the "registry_address" setting in SCF, which actually has been obsolete for a long time.
- InfluxDBPublisher agent is slightly modified, so it will exit on SIGINT (ctrl-c) while failing to find the influxdb server.
- ocs-local-support code is fixed to distinguish correctly between (a) crossbar is down (b) crossbar is up but realm and/or prefix are mismatched (c) crossbar is up and respon

## Motivation and Context

At the observatory we'll have a few very similar systems, e.g. sat1 and sat2, running as independent OCS instances.  In some situations (influxdb and grafana, primarily) we will have data from all systems available, and so the feeds can't have the exact same names.  That means we either need to carefully include "sat1" / "sat2" in every instance-id ... e.g. "observatory.sat1_acu", "observatory.sat2_acu"  OR take advantage of the configurable prefix and have the agent addresses be "sat1.acu", "sat2.acu".

## How Has This Been Tested?

I ran an OCS setup on a single host, with all the affected agents, plus a fake data agent.  Confirmed I could see the data appear in grafana and that data was showing up in aggregator output files.  All tests/ pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
