### PR TITLE
Cast tuple param before type check

### DIFF
--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -1389,6 +1389,9 @@ class ParamHandler:
                 # Free cast from int to float.
                 if type is float and isinstance(value, int):
                     value = float(value)
+                # Fix type after json conversion
+                if type is tuple and isinstance(value, list) and cast in [tuple, None]:
+                    value = tuple(value)
                 if not isinstance(value, type):
                     raise ParamError(f"Param '{key}'={value} is not of required type ({type})")
             if choices is not None:

--- a/tests/test_ocs_agent.py
+++ b/tests/test_ocs_agent.py
@@ -503,12 +503,14 @@ def test_params_get():
         'float_param': 1e8,
         'numerical_string_param': '145.12',
         'none_param': None,
+        'tuple_param': [20., 120.],  # gets cast to list by json conversion
     })
 
     # Basic successes
     params.get('int_param', type=int)
     params.get('string_param', type=str)
     params.get('float_param', type=float)
+    params.get('tuple_param', type=tuple)
 
     # Tricky successes
     params.get('int_param', type=float)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds tuple support to the `@ocs_agent.params` decorator.

Tuples inadvertently get cast to lists when converted to json as they are sent from the client to the agent, this just casts back to tuple when `type=tuple`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #274. Issue originally came up when using the ACU Agent in socs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Only tested in in the unit tests. But I made the test return exactly the error in #274 before applying the fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
