### PR TITLE
Support direct start calls with params to param decorated Tasks/Processes

### DIFF
--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -1304,6 +1304,8 @@ class ParamHandler:
     """
 
     def __init__(self, params):
+        if params is None:
+            params = {}
         self._params = params
         self._checked = set()
 
@@ -1374,11 +1376,7 @@ class ParamHandler:
 
         """
         self._checked.add(key)
-        if self._params is None and not isinstance(default, ParamError):
-            self._params = {}  # avoid attribute error in check_for_strays
-            value = default
-        else:
-            value = self._params.get(key, None)
+        value = self._params.get(key, None)
         is_unset = value is None and \
             (treat_none_as_missing or key not in self._params)
         if is_unset:

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -694,8 +694,10 @@ class OCSAgent(ApplicationSession):
                     handler = ParamHandler(params)
                     params = handler.batch(op.launcher._ocs_prescreen)
                 except ParamError as err:
+                    self.log.error(f"Caught ParamError during start call: {err}")
                     return (ocs.ERROR, err.msg, {})
                 except Exception as err:
+                    self.log.error(f"Caught Exception during start call: {err}")
                     return (ocs.ERROR, f'CRASH: during param pre-processing: {str(err)}', {})
 
             # Mark as started.

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -694,10 +694,10 @@ class OCSAgent(ApplicationSession):
                     handler = ParamHandler(params)
                     params = handler.batch(op.launcher._ocs_prescreen)
                 except ParamError as err:
-                    self.log.error(f"Caught ParamError during start call: {err}")
+                    self.log.error("Caught ParamError during start call: {err}", err=err)
                     return (ocs.ERROR, err.msg, {})
                 except Exception as err:
-                    self.log.error(f"Caught Exception during start call: {err}")
+                    self.log.error("Caught Exception during start call: {err}", err=err)
                     return (ocs.ERROR, f'CRASH: during param pre-processing: {str(err)}', {})
 
             # Mark as started.

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -1374,7 +1374,11 @@ class ParamHandler:
 
         """
         self._checked.add(key)
-        value = self._params.get(key, None)
+        if self._params is None and not isinstance(default, ParamError):
+            self._params = {}  # avoid attribute error in check_for_strays
+            value = default
+        else:
+            value = self._params.get(key, None)
         is_unset = value is None and \
             (treat_none_as_missing or key not in self._params)
         if is_unset:

--- a/tests/test_ocs_agent.py
+++ b/tests/test_ocs_agent.py
@@ -43,6 +43,12 @@ def tfunc_raise(session, a):
     return tfunc(session, a)
 
 
+@param('test', default=1)
+def tfunc_param_dec(session, a):
+    """tfunc but decorated with @ocs_agent.param."""
+    return True, 'Task completed successfully'
+
+
 @pytest.fixture
 def mock_agent():
     """Test fixture to setup a mocked OCSAgent.
@@ -259,6 +265,19 @@ def test_start_unregistered_task(mock_agent):
     assert res[0] == ocs.ERROR
     assert isinstance(res[1], str)
     assert res[2] == {}
+
+
+def test_start_task_none_params(mock_agent):
+    """Test passing params=None to task decorated with @param that has set
+    defaults.
+
+    See issue: https://github.com/simonsobs/ocs/issues/251
+
+    """
+    mock_agent.register_task('test_task', tfunc_param_dec)
+    res = mock_agent.start('test_task', params=None)
+    print(res)
+    assert res[0] == ocs.OK
 
 
 # Wait


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes a bug detailed in #251. The summary is that if a start call is made within an Agent and not passed any params (i.e. `params=None`) then the call fails silently.

Added to resolve this:
* Logging of caught exceptions when calling `self.agent.start()`. This provides some indication that the start call failed within the Agent logs (that is, the agent making the start call, not necessarily the Agent receiving the start.)
* A test for task start that replicates the error.
* Handling of `params=None` where we take the default value provided in the `@ocs_agent.param` decorator.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #251.

Direct calls like this are being used in a couple of active agent PRs in socs, including the HWP agents. Would be nice to finally fix this here.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I added a small task to the fake data agent locally that makes a start call to the acq process without passing an params, which reproduced the bug in #251. I then added the logging for the caught exceptions.

Then I added a test that would fail given the existing behavior, before implementing a fix. Once the fix was in place I ran the modified fake data agent task again and verified the acq process ran as expected with the default value from the param decorator.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
