### PR TITLE
Create `__repr__` for site_config classes

### DIFF
--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -47,6 +47,7 @@ class SiteConfig:
 
         """
         self = cls()
+        self.data = data
         for k, v in data.get('hosts', {}).items():
             assert (k not in self.hosts)  # duplicate host name in config file!
             self.hosts[k] = HostConfig.from_dict(v, parent=self, name=k)
@@ -61,6 +62,10 @@ class SiteConfig:
         self = cls.from_dict(data)
         self.source_file = filename
         return self
+
+    def __repr__(self):
+        repr_ = f'SiteConfig.from_dict({self.data})'
+        return repr_
 
 
 class HostConfig:
@@ -111,6 +116,11 @@ class HostConfig:
         self.log_dir = data.get('log-dir', None)
         return self
 
+    def __repr__(self):
+        repr_ = f'HostConfig.from_dict({self.data}, ' \
+            f'name={self.name})'
+        return repr_
+
 
 class CrossbarConfig:
     @classmethod
@@ -134,6 +144,7 @@ class CrossbarConfig:
         if data is None:
             return None
         self = cls()
+        self.data = data
         self.parent = parent
         self.binary = data.get('bin', shutil.which('crossbar'))
         self.cbdir = data.get('config-dir')
@@ -160,6 +171,10 @@ class CrossbarConfig:
 
     def __eq__(self, other):
         return self.binary == other.binary and self.cbdir == other.cbdir
+
+    def __repr__(self):
+        repr_ = f'CrossbarConfig.from_dict({self.data})'
+        return repr_
 
 
 class HubConfig:
@@ -201,6 +216,9 @@ class HubConfig:
 
     def summary(self):
         return summarize_dict(self.data)
+
+    def __repr__(self):
+        return f"HubConfig.from_dict({self.data})"
 
 
 class InstanceConfig:
@@ -250,6 +268,9 @@ class InstanceConfig:
         if self.manage is None:
             self.manage = "yes"
         return self
+
+    def __repr__(self):
+        return f"InstanceConfig.from_dict({self.data})"
 
 
 def summarize_dict(d):
@@ -308,6 +329,10 @@ class ArgContainer:
             arg_list.extend(v)
 
         return arg_list
+
+    def __repr__(self):
+        args = str(self.to_list())
+        return f'ArgContainer({args})'
 
 
 def add_arguments(parser=None):

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -158,6 +158,9 @@ class CrossbarConfig:
             'config-dir': self.cbdir,
         })
 
+    def __eq__(self, other):
+        return self.binary == other.binary and self.cbdir == other.cbdir
+
 
 class HubConfig:
     @classmethod


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR creates `__repr__` methods for each of the `site_config.py` classes. The returned string can be used to recreate the Config object with the exception of including the `parent`, which we leave out. (It created quite large representations.) (On that note -- why do we track the parent? As pointed out in the docs, it's never used.)

### Questions
I had one question/comment about these classes while working on this. Why do we have all of these alternative constructor classmethods when mostly there is only one way (`.from_dict()`) to construct the object anyway?

I thought it would make more sense to have the constructor in `.from_dict()` be the default constructor, which leaves the only alternative constructor to be `SiteConfig.from_yaml()`. I was going to include in this PR, but it makes things sort of messy for reviewing the `__repr__` work. You can see this rework here:
https://github.com/simonsobs/ocs/compare/koopman/site-config-object-reprs...koopman/remove-from-dict

If that makes sense, I can PR that change as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A few times recently I've needed to debug something related to these objects and having a way to easily print their contents is extremely useful in that case.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I wrote some tests while doing this, which use a shared dummy config that is written in the test. They mostly just assert that `cfg.data == data` essentially, which isn't particularly useful, but does test the objects can be made...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
