### PR TITLE
Allow user configurable agent timeout for crossbar disconnection

### DIFF
--- a/docs/user/site_config.rst
+++ b/docs/user/site_config.rst
@@ -180,6 +180,50 @@ and Control Clients (see below).
     If you're proceeding in the same terminal don't forget to source your
     ``.bashrc`` file.
 
+Crossbar Connection Timeout
+---------------------------
+If an Agent loses connection to the crossbar server it will be unable to
+publish any values to its Feeds. By default, the Agent stays online for 10
+seconds, waiting to remake the connection to crossbar. If it fails to do so, it
+will stop all running processes and shutdown.
+
+There may be instances where you would like the Agent to continue running its
+Processes, even if the connection to crossbar is lost for some amount of time
+or indefinitely. For these cases there is the ``crossbar-timeout`` argument.
+This can be set at the Host level, at the individual Agent level, passed on the
+commandline, or set via an environment variable. Setting the timeout to 0
+disabled the timeout, allowing the Agent to run indefinitely without a crossbar
+connection.
+
+.. note::
+    A crossbar connection is still required for initial startup of the Agent.
+
+To set at the host level:
+
+.. code-block:: yaml
+
+  hosts:
+    host-1: {
+
+      # Set timeout to 20 seconds for all Agents on this host
+      'crossbar-timeout': 20,
+
+      'agent-instances': [
+        # crossbar timeout set to 30 seconds
+        {'agent-class': 'Lakeshore240Agent',
+         'instance-id': 'thermo1',
+         'arguments': [['--serial-number', 'LSA11AA'],
+                       ['--mode', 'idle'],
+                       ['--crossbar-timeout', 30]]},
+        # crossbar timeout disabled
+        {'agent-class': 'Lakeshore240Agent',
+         'instance-id': 'thermo2',
+         'arguments': [['--serial-number', 'LSA22BB'],
+                       ['--mode', 'acq'],
+                       ['--crossbar-timeout', 0]]},
+      ]
+    }
+
 Commandline Arguments
 =====================
 There are several built in commandline arguments that can be passed to Agents

--- a/ocs/agent_cli.py
+++ b/ocs/agent_cli.py
@@ -48,7 +48,7 @@ def _get_parser():
     # Default set in site_config.py within add_arguments()
     parser.add_argument('--crossbar-timeout', type=int, help="Length of time in seconds "
                         "that the Agent will try to reconnect to the crossbar server before "
-                        "shutting down.")
+                        "shutting down. Disable the timeout by setting to 0.")
 
     # Not passed through to Agent
     parser.add_argument('--agent', default=None, help="Path to non-plugin OCS Agent.")

--- a/ocs/agent_cli.py
+++ b/ocs/agent_cli.py
@@ -24,7 +24,8 @@ To start an Agent, run::
 ``ocs-agent-cli`` will also inspect environment variables for commonly passed
 arguments to facilitate configuration within Docker containers. Supported
 arguments include, ``--instance-id`` as ``INSTANCE_ID``, ``--site-hub`` as
-``SITE_HUB``, and ``--site-http`` as ``SITE_HTTP``.
+``SITE_HUB``, ``--site-http`` as ``SITE_HTTP``, and ``--crossbar-timeout`` as
+``CROSSBAR_TIMEOUT``.
 
 ``ocs-agent-cli`` relies on the Agent being run belonging to an OCS Plugin. If
 the Agent is not an OCS Plugin it can be run directly using both the
@@ -44,6 +45,10 @@ def _get_parser():
     parser.add_argument('--instance-id', default=None, help="Agent unique instance-id. E.g. 'aggregator' or 'fakedata-1'.")
     parser.add_argument('--site-hub', default=None, help="Site hub address.")
     parser.add_argument('--site-http', default=None, help="Site HTTP address.")
+    # Default set in site_config.py within add_arguments()
+    parser.add_argument('--crossbar-timeout', type=int, help="Length of time in seconds "
+                        "that the Agent will try to reconnect to the crossbar server before "
+                        "shutting down.")
 
     # Not passed through to Agent
     parser.add_argument('--agent', default=None, help="Path to non-plugin OCS Agent.")
@@ -133,14 +138,15 @@ def main(args=None):
     # Format is {"arg name within argparse": "ENVIRONMENT VARIABLE NAME"}
     # E.g. --my-new-arg should be {"my_new_arg": "MY_NEW_ARG"}
     optional_env = {"site_hub": "SITE_HUB",
-                    "site_http": "SITE_HTTP"}
+                    "site_http": "SITE_HTTP",
+                    "crossbar_timeout": "CROSSBAR_TIMEOUT"}
 
     for _name, _var in optional_env.items():
         # Args passed on cli take priority
         _arg = vars(pre_args)[_name]
         _flag = f"--{_name}".replace('_', '-')
         if _arg is not None:
-            post_args.extend([_flag, _arg])
+            post_args.extend([_flag, str(_arg)])
             continue
 
         # Get from ENV if not passed w/flag

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -270,11 +270,7 @@ class OCSAgent(ApplicationSession):
 
         # Wait forever
         if timeout == 0:
-            while True:
-                if self.realm_joined:
-                    return
-
-                yield dsleep(1)
+            return
 
         # compute_delay(attempts): Delay in seconds given number of attempts
         # Twisted has an exponential backoff interval that prevents flooding

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -157,6 +157,15 @@ class OCSAgent(ApplicationSession):
     """
 
     def onConnect(self):
+        # Define signal handlers
+        @inlineCallbacks
+        def signal_handler(sig, frame):
+            self.log.info('caught {signal}!', signal=signal.Signals(sig).name)
+            yield self._shutdown()
+
+        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGTERM, signal_handler)
+
         self.log.info('transport connected')
         self.join(self.config.realm)
 
@@ -258,15 +267,6 @@ class OCSAgent(ApplicationSession):
 
         # Wait to see if we reconnect before stopping the reactor
         timeout = self.site_args.crossbar_timeout
-
-        # Define signal handlers to interrupt during wait for reconnection
-        @inlineCallbacks
-        def signal_handler(sig, frame):
-            self.log.info('caught {signal}!', signal=signal.Signals(sig).name)
-            yield self._shutdown()
-
-        signal.signal(signal.SIGINT, signal_handler)
-        signal.signal(signal.SIGTERM, signal_handler)
 
         # Wait forever
         if timeout == 0:

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -370,27 +370,28 @@ def add_arguments(parser=None):
     if parser is None:
         parser = argparse.ArgumentParser()
     group = parser.add_argument_group('Site Config Options')
-    group.add_argument('--site', help="""Instead of the default site, use the configuration for the
-       specified site.  The configuration is loaded from
-       ``$OCS_CONFIG_DIR/{site}.yaml``.  If ``--site=none``, the
-       site_config facility will not be used at all.""")
-    group.add_argument('--site-file', help="""Instead of the default site config, use the specified file.  Full
-       path must be specified.""")
-    group.add_argument('--site-host', help="""Override the OCS determination of what host this instance is
-       running on, and instead use the configuration for the indicated
-       host.""")
-    group.add_argument('--site-hub', help="""Override the ocs hub url (wamp_server).""")
-    group.add_argument('--site-http', help="""Override the ocs hub http url (wamp_http).""")
-    group.add_argument('--site-realm', help="""Override the ocs hub realm (wamp_realm).""")
-    group.add_argument('--instance-id', help="""Look in the SCF for Agent-instance specific configuration options,
-       and use those to launch the Agent.""")
-    group.add_argument('--address-root', help="""Override the site default address root.""")
-    group.add_argument('--registry-address', help="""Deprecated.""")
-    group.add_argument('--log-dir', help="""Set the logging directory.""")
-    group.add_argument('--working-dir', help="""Propagate the working directory.""")
-    group.add_argument('--crossbar-timeout', type=int, default=10, help="""Length of time in seconds
-       that the Agent will try to reconnect to the crossbar server before
-       shutting down.""")
+    group.add_argument('--site', help="Instead of the default site, use the "
+                       "configuration for the specified site.  The configuration is loaded "
+                       "from ``$OCS_CONFIG_DIR/{site}.yaml``.  If ``--site=none``, the "
+                       "site_config facility will not be used at all.")
+    group.add_argument('--site-file', help="Instead of the default site config, "
+                       "use the specified file. Full path must be specified.")
+    group.add_argument('--site-host', help="Override the OCS determination of "
+                       "what host this instance is running on, and instead use the "
+                       "configuration for the indicated host.")
+    group.add_argument('--site-hub', help="Override the ocs hub url (wamp_server).")
+    group.add_argument('--site-http', help="Override the ocs hub http url (wamp_http).")
+    group.add_argument('--site-realm', help="Override the ocs hub realm (wamp_realm).")
+    group.add_argument('--instance-id', help="Look in the SCF for "
+                       "Agent-instance specific configuration options, and use those to launch "
+                       "the Agent.")
+    group.add_argument('--address-root', help="Override the site default address root.")
+    group.add_argument('--registry-address', help="Deprecated.")
+    group.add_argument('--log-dir', help="Set the logging directory.")
+    group.add_argument('--working-dir', help="Propagate the working directory.")
+    group.add_argument('--crossbar-timeout', type=int, default=10, help="Length of time in seconds "
+                       "that the Agent will try to reconnect to the crossbar server before "
+                       "shutting down. Note this is set per Agent in an instance's arguments list.")
     return parser
 
 

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -362,6 +362,10 @@ def add_arguments(parser=None):
     ``--working-dir=...``:
         Propagate the working directory.
 
+    ``--crossbar-timeout=...``:
+        Length of time in seconds that the Agent will try to reconnect to the
+        crossbar server before shutting down.
+
     """
     if parser is None:
         parser = argparse.ArgumentParser()
@@ -384,6 +388,9 @@ def add_arguments(parser=None):
     group.add_argument('--registry-address', help="""Deprecated.""")
     group.add_argument('--log-dir', help="""Set the logging directory.""")
     group.add_argument('--working-dir', help="""Propagate the working directory.""")
+    group.add_argument('--crossbar-timeout', type=int, default=10, help="""Length of time in seconds
+       that the Agent will try to reconnect to the crossbar server before
+       shutting down.""")
     return parser
 
 

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -70,6 +70,7 @@ class HostConfig:
         self.agent_paths = []
         self.log_dir = None
         self.working_dir = os.getcwd()
+        self.crossbar_timeout = None
 
     @classmethod
     def from_dict(cls, data, parent=None, name=None):
@@ -109,6 +110,7 @@ class HostConfig:
         self.agent_paths = data.get('agent-paths', [])
         self.crossbar = CrossbarConfig.from_dict(data.get('crossbar'))
         self.log_dir = data.get('log-dir', None)
+        self.crossbar_timeout = data.get('crossbar_timeout', 10)
         return self
 
 
@@ -389,7 +391,7 @@ def add_arguments(parser=None):
     group.add_argument('--registry-address', help="Deprecated.")
     group.add_argument('--log-dir', help="Set the logging directory.")
     group.add_argument('--working-dir', help="Propagate the working directory.")
-    group.add_argument('--crossbar-timeout', type=int, default=10, help="Length of time in seconds "
+    group.add_argument('--crossbar-timeout', type=int, help="Length of time in seconds "
                        "that the Agent will try to reconnect to the crossbar server before "
                        "shutting down. Note this is set per Agent in an instance's arguments list.")
     return parser
@@ -518,6 +520,8 @@ def add_site_attributes(args, site, host=None):
         args.address_root = site.hub.data['address_root']
     if (args.log_dir is None) and (host is not None):
         args.log_dir = host.log_dir
+    if (args.crossbar_timeout is None) and (host is not None):
+        args.crossbar_timeout = host.crossbar_timeout
 
 
 @deprecation.deprecated(deprecated_in='v0.6.0',

--- a/ocs/testing.py
+++ b/ocs/testing.py
@@ -11,7 +11,7 @@ from urllib.error import URLError
 from ocs.ocs_client import OCSClient
 
 
-SIGINT_TIMEOUT = 5
+SIGINT_TIMEOUT = 10
 
 
 def create_agent_runner_fixture(agent_path, agent_name, args=None):

--- a/tests/integration/test_crossbar_integration.py
+++ b/tests/integration/test_crossbar_integration.py
@@ -165,7 +165,7 @@ def test_proper_agent_shutdown_on_lost_transport(wait_for_crossbar):
     crossbar_container.stop()
 
     # 15 seconds should be enough with default 10 second timeout
-    timeout = 15
+    timeout = 25
     while timeout > 0:
         time.sleep(1)  # give time for the fake-data-agent to timeout, then shutdown
         fake_data_container = client.containers.get('ocs-tests-fake-data-agent')

--- a/tests/integration/test_crossbar_integration.py
+++ b/tests/integration/test_crossbar_integration.py
@@ -164,7 +164,7 @@ def test_proper_agent_shutdown_on_lost_transport(wait_for_crossbar):
     crossbar_container = client.containers.get('ocs-tests-crossbar')
     crossbar_container.stop()
 
-    # 15 seconds should be enough with default 10 second timeout
+    # 25 seconds should be enough with default 10 second timeout
     timeout = 25
     while timeout > 0:
         time.sleep(1)  # give time for the fake-data-agent to timeout, then shutdown


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR introduces a per Agent configurable agent time. This allows the user to set how long after the Agent loses connection to the crossbar server the Agent waits before cleaning up and shutting down.

A summary of changes:
* Added crossbar-timeout argument globally to the site arguments and to ocs-agent-cli.
* Implemented the same exponential backoff policy as twisted uses to reconnect to the crossbar server so wait times roughly line up (up to some random jitter.)
* Implemented signal handling so the Agent can be interrupted when crossbar-timeout is 0.
* Fixed some docstring formatting in the argparse "help" strings.

### Usage
This timeout is available as a commandline argument `--crossbar-timeout`, which can also be set in the SCF in an individual instance's 'arguments' list, for example:
```
      {'agent-class': 'FakeDataAgent',
       'instance-id': 'fake-data1',
       'arguments': [['--crossbar-timeout', 0],
                     ['--mode', 'acq'],
                     ['--num-channels', '2'],
                     ['--sample-rate', '1']]},
```

And example on the command line:

```
ocs-agent-cli --instance-id fake-data1 --crossbar-timeout=40
```

Or in a docker-compose file:
```
  fake-data1:
      image: ocs:test
      hostname: ocs-docker
      environment:
        - LOGLEVEL=info
        - INSTANCE_ID=fake-data1
        - CROSSBAR_TIMEOUT=21
      volumes:
        - $OCS_CONFIG_DIR:/config:ro
```

A crossbar-timeout of 0 is special and will disable the timeout, allowing the Agent to run forever through a crossbar outage.

### Logging
Upon disconnecting the Agent logs will display (note there are some debug statements active here indicating the top of the acquisition loop in the fake data agent):
```
2023-06-05T19:43:54+0000 session left: CloseDetails(reason=<wamp.close.transport_lost>, message='WAMP transport was lost without closing the session 6165510818002603 before')
2023-06-05T19:43:54+0000 transport disconnected
2023-06-05T19:43:54+0000 waiting for reconnection
2023-06-05T19:43:54+0000 waiting at least 20.999996662139893 more seconds before giving up
2023-06-05T19:43:54+0000 Scheduling retry 1 to connect <twisted.internet.endpoints.TCP4ClientEndpoint object at 0x7fe4e2a3b550> in 2.371031904796556 seconds.
2023-06-05T19:43:54+0000 Top of the acq while loop
2023-06-05T19:43:55+0000 Top of the acq while loop
2023-06-05T19:43:55+0000 Could not publish to Feed. TransportLost. crossbar server likely unreachable.
2023-06-05T19:43:56+0000 Top of the acq while loop
2023-06-05T19:43:56+0000 Scheduling retry 2 to connect <twisted.internet.endpoints.TCP4ClientEndpoint object at 0x7fe4e2a3b550> in 2.9836467052303157 seconds.
2023-06-05T19:43:56+0000 waiting at least 18.56661033630371 more seconds before giving up
2023-06-05T19:43:57+0000 Top of the acq while loop
2023-06-05T19:43:58+0000 Top of the acq while loop
2023-06-05T19:43:58+0000 Could not publish to Feed. TransportLost. crossbar server likely unreachable.
2023-06-05T19:43:59+0000 Top of the acq while loop
2023-06-05T19:43:59+0000 Scheduling retry 3 to connect <twisted.internet.endpoints.TCP4ClientEndpoint object at 0x7fe4e2a3b550> in 4.081454896115918 seconds.
2023-06-05T19:43:59+0000 waiting at least 15.355729341506958 more seconds before giving up
2023-06-05T19:44:00+0000 Top of the acq while loop
2023-06-05T19:44:01+0000 Top of the acq while loop
2023-06-05T19:44:01+0000 Could not publish to Feed. TransportLost. crossbar server likely unreachable.
2023-06-05T19:44:02+0000 Top of the acq while loop
2023-06-05T19:44:03+0000 Top of the acq while loop
2023-06-05T19:44:03+0000 waiting at least 11.623907089233398 more seconds before giving up
2023-06-05T19:44:03+0000 Scheduling retry 4 to connect <twisted.internet.endpoints.TCP4ClientEndpoint object at 0x7fe4e2a3b550> in 5.853152524023113 seconds.
2023-06-05T19:44:04+0000 Top of the acq while loop
2023-06-05T19:44:04+0000 Could not publish to Feed. TransportLost. crossbar server likely unreachable.
2023-06-05T19:44:05+0000 Top of the acq while loop
2023-06-05T19:44:06+0000 Top of the acq while loop
2023-06-05T19:44:06+0000 Could not publish to Feed. TransportLost. crossbar server likely unreachable.
2023-06-05T19:44:07+0000 Top of the acq while loop
2023-06-05T19:44:08+0000 Top of the acq while loop
2023-06-05T19:44:09+0000 waiting at least 5.961486339569092 more seconds before giving up
2023-06-05T19:44:09+0000 Top of the acq while loop
2023-06-05T19:44:09+0000 Could not publish to Feed. TransportLost. crossbar server likely unreachable.
2023-06-05T19:44:09+0000 Scheduling retry 5 to connect <twisted.internet.endpoints.TCP4ClientEndpoint object at 0x7fe4e2a3b550> in 8.363641698118796 seconds.
2023-06-05T19:44:10+0000 Top of the acq while loop
2023-06-05T19:44:11+0000 Top of the acq while loop
2023-06-05T19:44:11+0000 Could not publish to Feed. TransportLost. crossbar server likely unreachable.
2023-06-05T19:44:12+0000 Top of the acq while loop
2023-06-05T19:44:13+0000 Top of the acq while loop
2023-06-05T19:44:14+0000 Top of the acq while loop
2023-06-05T19:44:14+0000 Could not publish to Feed. TransportLost. crossbar server likely unreachable.
2023-06-05T19:44:15+0000 Top of the acq while loop
2023-06-05T19:44:16+0000 Top of the acq while loop
2023-06-05T19:44:16+0000 Could not publish to Feed. TransportLost. crossbar server likely unreachable.
2023-06-05T19:44:17+0000 Top of the acq while loop
2023-06-05T19:44:17+0000 Stopping all running sessions
2023-06-05T19:44:17+0000 Stopping session acq
2023-06-05T19:44:17+0000 stop called for acq
2023-06-05T19:44:17+0000 Stopping session count
2023-06-05T19:44:17+0000 stop called for count
2023-06-05T19:44:17+0000 Unable to publish status. TransportLost. crossbar server likely unreachable.
2023-06-05T19:44:17+0000 count:1 Status is now "stopping".
2023-06-05T19:44:17+0000 Stopper for "count" terminated with ok=True and message (None,)
2023-06-05T19:44:17+0000 stopping reactor
2023-06-05T19:44:18+0000 Top of the acq while loop
2023-06-05T19:44:18+0000 Main loop terminated.
```

### Questions/Self Comments
I'm not sure the best place to document this. It's in the argparse help for the site config arguments and in ocs-agent-cli, maybe that's sufficient? Feedback welcome here.

I've kept the default to 10 seconds, since that's what we've had. Do want to keep this or change it?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #331.

Ever since https://github.com/simonsobs/ocs/pull/180 this timeout has been 10 seconds. But we need the ability to have Agents continue to run indefinitely while the crossbar server might be down, this allows agents like the HWP agents in socs to continue to command the hardware, even if the Agent can't communicate with the rest of the network.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've tested this locally with a collection of fake data agents.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
