### PR TITLE
Replace pytest-docker-compose with pytest-docker plugin

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-cov
 docker
-pytest-docker-compose
+pytest-docker
 pytest-twisted
 so3g

--- a/tests/integration/test_aggregator_agent_integration.py
+++ b/tests/integration/test_aggregator_agent_integration.py
@@ -11,8 +11,7 @@ from ocs.testing import (
 from integration.util import (
     create_crossbar_fixture
 )
-
-pytest_plugins = ("docker_compose")
+from integration.util import docker_compose_file  # noqa: F401
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(

--- a/tests/integration/test_crossbar_integration.py
+++ b/tests/integration/test_crossbar_integration.py
@@ -8,9 +8,7 @@ from ocs.ocs_client import OCSClient
 from so3g import hk
 
 from integration.util import create_crossbar_fixture, restart_crossbar
-
-pytest_plugins = ("docker_compose",)
-
+from integration.util import docker_compose_file  # noqa: F401
 
 wait_for_crossbar = create_crossbar_fixture()
 
@@ -177,3 +175,6 @@ def test_proper_agent_shutdown_on_lost_transport(wait_for_crossbar):
 
     fake_data_container = client.containers.get('ocs-tests-fake-data-agent')
     assert fake_data_container.status == "exited"
+
+    # Restart crossbar, else docker plugin loses track of it
+    crossbar_container.start()

--- a/tests/integration/test_fake_data_agent_integration.py
+++ b/tests/integration/test_fake_data_agent_integration.py
@@ -11,10 +11,9 @@ from ocs.testing import (
 from integration.util import (
     create_crossbar_fixture,
 )
+from integration.util import docker_compose_file  # noqa: F401
 
 AGENT_PATH = '../ocs/agents/fake_data/agent.py'
-
-pytest_plugins = ("docker_compose")
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(

--- a/tests/integration/test_host_manager_agent_integration.py
+++ b/tests/integration/test_host_manager_agent_integration.py
@@ -14,9 +14,7 @@ from ocs.testing import (
 from integration.util import (
     create_crossbar_fixture
 )
-
-pytest_plugins = ("docker_compose")
-
+from integration.util import docker_compose_file  # noqa: F401
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture('../ocs/agents/host_manager/agent.py',

--- a/tests/integration/test_influxdb_publisher_integration.py
+++ b/tests/integration/test_influxdb_publisher_integration.py
@@ -11,8 +11,7 @@ from ocs.testing import (
 from integration.util import (
     create_crossbar_fixture
 )
-
-pytest_plugins = ("docker_compose")
+from integration.util import docker_compose_file  # noqa: F401
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture(

--- a/tests/integration/test_registry_agent_integration.py
+++ b/tests/integration/test_registry_agent_integration.py
@@ -9,10 +9,9 @@ from ocs.testing import (
 from integration.util import (
     create_crossbar_fixture
 )
+from integration.util import docker_compose_file  # noqa: F401
 
 from ocs.base import OpCode
-
-pytest_plugins = ("docker_compose")
 
 wait_for_crossbar = create_crossbar_fixture()
 run_agent = create_agent_runner_fixture('../ocs/agents/registry/agent.py',

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import docker
 
@@ -7,13 +9,10 @@ from ocs.testing import check_crossbar_connection
 def create_crossbar_fixture():
     # Fixture to wait for crossbar server to be available.
     # Speeds up tests a bit to have this session scoped
-    # If tests start interfering with one another this should be changed to
-    # "function" scoped and session_scoped_container_getter should be changed
-    # to function_scoped_container_getter
-    # @pytest.fixture(scope="session")
-    # def wait_for_crossbar(session_scoped_container_getter):
-    @pytest.fixture(scope="function")
-    def wait_for_crossbar(function_scoped_container_getter):
+    # If tests interfere with eachother change to "function" scoped
+    # @pytest.fixture(scope="function")
+    @pytest.fixture(scope="session")
+    def wait_for_crossbar(docker_services):
         """Wait for the crossbar server from docker-compose to become
         responsive.
 
@@ -29,3 +28,10 @@ def restart_crossbar():
     crossbar_container = client.containers.get('ocs-tests-crossbar')
     crossbar_container.restart()
     check_crossbar_connection()
+
+
+# Overrides the default location that pytest-docker looks for the compose file.
+# https://pypi.org/project/pytest-docker/
+@pytest.fixture(scope="session")
+def docker_compose_file(pytestconfig):
+    return os.path.join(str(pytestconfig.rootdir), "docker-compose.yml")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Following the lead of https://github.com/simonsobs/socs/pull/484, this replaces the pytest plugin `pytest-docker-compose` with the `pytest-docker` plugin.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`pytest-docker-compose` only supports docker-compose v1, which is now deprecated.

Replacing this in socs fixed docs builds that were failing for the same reason that we're seeing here, so I expect this to help.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran tests locally. I found that I didn't need the function scoped container execution, so I've switched back to session scoped, which reduces the time to run the tests a bit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
