### PR TITLE
systemd service file: add RestartSec=10s

### DIFF
--- a/docs/user/centralized_management.rst
+++ b/docs/user/centralized_management.rst
@@ -476,6 +476,7 @@ should look something like this::
   ExecStart=/home/ocs/git/ocs-site-configs/my-lab/launcher-hm-server5.sh
   User=ocs
   Restart=always
+  RestartSec=10s
 
   [Install]
   WantedBy=multi-user.target

--- a/ocs/ocs_systemd.py
+++ b/ocs/ocs_systemd.py
@@ -28,6 +28,7 @@ Description=OCS HostManager{host_detail}
 ExecStart={cmd}
 User={service_user}
 Restart=always
+RestartSec=10s
 {environment_lines}
 
 [Install]


### PR DESCRIPTION
HostManager can crash and restart really quickly, so this rate-limiting is necessary on some systems to prevent systemd from giving up on the service.

I think this is what is needed to solve #343 .  Pending better logs from the field, I don't know what else to do.

I confirmed on my system that without this rate limiter, systemd quickly gives up on trying to restart the agent (even though Restart=always).  With the limit in place, it seems to happily truck along for many minutes.