### PR TITLE
Add SITE_HOST envvar to ocs-agent-cli

### DIFF
--- a/docs/developer/docker.rst
+++ b/docs/developer/docker.rst
@@ -104,6 +104,10 @@ Environment variables used to configure the Agent are listed in the following ta
    * - ``INSTANCE_ID``
      - ``--instance-id``
      - Agent instance-id, e.g. ``aggregator``
+   * - ``SITE_HOST``
+     - ``--site-host``
+     - Hostname to use when looking up the instance configuration in
+       the Site Config File, e.g. ``host1``.
    * - ``SITE_HUB``
      - ``--site-hub``
      - WAMP server address, e.g. ``ws://10.10.10.10:8001/ws``

--- a/ocs/agent_cli.py
+++ b/ocs/agent_cli.py
@@ -21,10 +21,18 @@ To start an Agent, run::
 
   ocs-agent-cli --instance-id INSTANCE_ID
 
-``ocs-agent-cli`` will also inspect environment variables for commonly passed
-arguments to facilitate configuration within Docker containers. Supported
-arguments include, ``--instance-id`` as ``INSTANCE_ID``, ``--site-hub`` as
-``SITE_HUB``, and ``--site-http`` as ``SITE_HTTP``.
+``ocs-agent-cli`` will also inspect environment variables for commonly
+passed arguments to facilitate configuration within Docker containers.
+Those environment variables, if defined and non-trivial, will be
+passed to the agent script unless they are overridden explicitly on
+the ``ocs-agent-cli`` command line.  The environment variables and
+arguments are:
+
+  - ``INSTANCE_ID``, will be the default value for ``--instance-id``
+  - ``SITE_HOST``, for ``--site-host``
+  - ``SITE_HUB``, for ``--site-hub``
+  - ``SITE_HTTP``, for ``--site-http``
+
 
 ``ocs-agent-cli`` relies on the Agent being run belonging to an OCS Plugin. If
 the Agent is not an OCS Plugin it can be run directly using both the
@@ -44,6 +52,7 @@ def _get_parser():
     parser.add_argument('--instance-id', default=None, help="Agent unique instance-id. E.g. 'aggregator' or 'fakedata-1'.")
     parser.add_argument('--site-hub', default=None, help="Site hub address.")
     parser.add_argument('--site-http', default=None, help="Site HTTP address.")
+    parser.add_argument('--site-host', default=None, help="Declare the host the instance is configured in.")
 
     # Not passed through to Agent
     parser.add_argument('--agent', default=None, help="Path to non-plugin OCS Agent.")
@@ -133,7 +142,9 @@ def main(args=None):
     # Format is {"arg name within argparse": "ENVIRONMENT VARIABLE NAME"}
     # E.g. --my-new-arg should be {"my_new_arg": "MY_NEW_ARG"}
     optional_env = {"site_hub": "SITE_HUB",
-                    "site_http": "SITE_HTTP"}
+                    "site_http": "SITE_HTTP",
+                    "site_host": "SITE_HOST",
+                    }
 
     for _name, _var in optional_env.items():
         # Args passed on cli take priority


### PR DESCRIPTION
## Description

See above.

## Motivation and Context

Primary motivation is to make it easier to configure a single HostManager to control all agents on a physical host, including ones managed through docker and a docker-compose.yaml file.

In our new docker service definition scheme, environment variables are used to set basic agent configuration.  This adds SITE_HOST to INSTANCE_ID, SITE_HUB, SITE_HTTP.  The SITE_* ones can be defined in an anchor, and used throughout the docker-compose file; e.g.:

```version: '2'
x-basic-env:
    &basic-env
    SITE_HOST: host1
    LOGLEVEL: debug

services:
  ocs-faker1:
    image: ocs:latest
    hostname: host1-docker
    environment:
      <<: *basic-env
      INSTANCE_ID: faker1
    network_mode: host
    volumes:
      - ./:/config:ro

```

Use of anchors in this way does require treating environment as a dict rather than a list.

## How Has This Been Tested?

Directly by manipulating the configuration of the docker-compose.yaml.  The argument remains optional, and has the correct default behaviors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
