### PR TITLE
Improvements to session.status

### DIFF
--- a/docs/developer/clients.rst
+++ b/docs/developer/clients.rst
@@ -216,6 +216,32 @@ of a Task::
     else:
         print('Task did not complete successfully')
 
+Check Health of a Process
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Usually it's good when a Process is still running, but some Processes
+will also mark themselves as "degraded" if there is some non-fatal
+problem that means the acquisition or control is not occurring::
+
+    from ocs.ocs_client import OCSClient
+
+    client = OCSClient('agent-instance-id')
+
+    client.some_process.start()
+    time.sleep(2)
+    status = client.some_process()
+
+    if response.session['success'] is None:
+        if response.session['degraded']:
+            print('Process is running, but in a degraded state.')
+        else:
+            print('Process is running (and does not report degraded state).')
+    elif response.session['success']:
+        print('Process exited without error')
+    else:
+        print('Process exited with error')
+
+
 Check Latest Data in an Operation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/developer/session-data.rst
+++ b/docs/developer/session-data.rst
@@ -56,7 +56,6 @@ Fake Data Agent as an example, specifically at its primary Process,
         """
         ok, msg = self.try_set_job('acq')
         if not ok: return ok, msg
-        session.set_status('running')
 
         if params is None:
             params = {}

--- a/docs/developer/writing_an_agent/logging.rst
+++ b/docs/developer/writing_an_agent/logging.rst
@@ -96,8 +96,6 @@ Our Agent in full now looks like this:
                      "timestamp":1600448753.9288929}
 
             """
-            session.set_status('running')
-
             # Initialize the counter
             self._count=True
             counter = 0
@@ -139,9 +137,6 @@ Our Agent in full now looks like this:
                      'last_updated': 1660249321.8729222}
 
             """
-            # Set operations status to 'running'
-            session.set_status('running')
-
             # Log the text provided to the Agent logs
             self.log.info(f"{params['text']}")
 

--- a/docs/developer/writing_an_agent/process.rst
+++ b/docs/developer/writing_an_agent/process.rst
@@ -27,8 +27,6 @@ two more class methods:
                  "timestamp": 1600448753.9288929}
 
         """
-        session.set_status('running')
-
         # Initialize the counter
         self._count=True
         counter = 0
@@ -123,8 +121,6 @@ Our Agent in full now looks like this:
                      "timestamp": 1600448753.9288929}
 
             """
-            session.set_status('running')
-
             # Initialize the counter
             self._count=True
             counter = 0
@@ -166,9 +162,6 @@ Our Agent in full now looks like this:
                      'last_updated': 1660249321.8729222}
 
             """
-            # Set operations status to 'running'
-            session.set_status('running')
-
             # Print the text provided to the Agent logs
             print(f"{params['text']}")
 

--- a/docs/developer/writing_an_agent/publish.rst
+++ b/docs/developer/writing_an_agent/publish.rst
@@ -128,8 +128,6 @@ Our Agent in full now looks like this:
                           f"is held by {self.lock.job}")
                     return False
 
-                session.set_status('running')
-
                 # Initialize last release time for lock
                 last_release = time.time()
 
@@ -196,9 +194,6 @@ Our Agent in full now looks like this:
                     self.log.warn("Lock could not be acquired because it " +
                                   f"is held by {self.lock.job}")
                     return False
-
-                # Set operations status to 'running'
-                session.set_status('running')
 
                 # Log the text provided to the Agent logs
                 self.log.info(f"{params['text']}")

--- a/docs/developer/writing_an_agent/task.rst
+++ b/docs/developer/writing_an_agent/task.rst
@@ -26,9 +26,6 @@ here:
                  'last_updated': 1660249321.8729222}
 
         """
-        # Set operations status to 'running'
-        session.set_status('running')
-
         # Print the text provided
         print(f"{params['text']}")
 
@@ -181,9 +178,6 @@ Our full Agent so far should look like this:
                      'last_updated': 1660249321.8729222}
 
             """
-            # Set operations status to 'running'
-            session.set_status('running')
-
             # Print the text provided
             print(f"{params['text']}")
 

--- a/docs/developer/writing_an_agent/timeoutlock.rst
+++ b/docs/developer/writing_an_agent/timeoutlock.rst
@@ -19,8 +19,6 @@ Process would look like this:
                               f"{self.lock.job} is already running")
                 return False, "Could not acquire lock"
 
-            session.set_status('running')
-
             # Initialize the counter
             self._count=True
             counter = 0
@@ -44,9 +42,6 @@ Process would look like this:
                 self.log.warn(f"Could not start Task because"
                               f"{self.lock.job} is already running")
                 return False, "Could not acquire lock"
-
-            # Set operations status to 'running'
-            session.set_status('running')
 
             # Log the text provided to the Agent logs
             self.log.info(f"{params['text']}")
@@ -148,8 +143,6 @@ Our Agent in full now looks like this:
                           f"is held by {self.lock.job}")
                     return False
 
-                session.set_status('running')
-
                 # Initialize last release time for lock
                 last_release = time.time()
 
@@ -207,9 +200,6 @@ Our Agent in full now looks like this:
                     self.log.warn("Lock could not be acquired because it " +
                                   f"is held by {self.lock.job}")
                     return False
-
-                # Set operations status to 'running'
-                session.set_status('running')
 
                 # Log the text provided to the Agent logs
                 self.log.info(f"{params['text']}")

--- a/ocs/agents/aggregator/agent.py
+++ b/ocs/agents/aggregator/agent.py
@@ -110,7 +110,6 @@ class AggregatorAgent:
                          "last_block_received": "temps"}}}
 
         """
-        session.set_status('starting')
         self.aggregate = True
 
         try:
@@ -126,7 +125,6 @@ class AggregatorAgent:
             reactor.callFromThread(reactor.stop)
             return False, "Aggregation not started"
 
-        session.set_status('running')
         while self.aggregate:
             time.sleep(self.loop_time)
             aggregator.run()

--- a/ocs/agents/barebones/agent.py
+++ b/ocs/agents/barebones/agent.py
@@ -66,8 +66,6 @@ class BarebonesAgent:
                       + f"is held by {self.lock.job}")
                 return False
 
-            session.set_status('running')
-
             # Initialize last release time for lock
             last_release = time.time()
 
@@ -134,9 +132,6 @@ class BarebonesAgent:
                 self.log.warn("Lock could not be acquired because it "
                               + f"is held by {self.lock.job}")
                 return False
-
-            # Set operations status to 'running'
-            session.set_status('running')
 
             # Log the text provided to the Agent logs
             self.log.info(f"{params['text']}")

--- a/ocs/agents/fake_data/agent.py
+++ b/ocs/agents/fake_data/agent.py
@@ -92,11 +92,9 @@ class FakeDataAgent:
         reporting_interval = 1.
         next_report = next_timestamp + reporting_interval
 
-        is_degraded = False
         next_deg_flip = None
         if params['degradation_period'] is not None:
             next_deg_flip = 0
-        session.data['degraded'] = is_degraded
 
         self.log.info("Starting acquisition")
 
@@ -112,9 +110,8 @@ class FakeDataAgent:
             now = time.time()
 
             if next_deg_flip is not None and now > next_deg_flip:
-                is_degraded = not is_degraded
+                session.degraded = not session.degraded
                 next_deg_flip = now + params['degradation_period']
-                session.data['degraded'] = is_degraded
 
             delay_time = next_report - now
             if delay_time > 0:

--- a/ocs/agents/fake_data/agent.py
+++ b/ocs/agents/fake_data/agent.py
@@ -80,7 +80,6 @@ class FakeDataAgent:
         ok, msg = self.try_set_job('acq')
         if not ok:
             return ok, msg
-        session.set_status('running')
 
         T = [.100 for c in self.channel_names]
         block = ocs_feed.Block('temps', self.channel_names)
@@ -170,7 +169,6 @@ class FakeDataAgent:
         # This process runs entirely in the reactor, as does its stop function.
         session.data = {'counter': 0,
                         'last_update': time.time()}
-        session.set_status('running')
         while session.status == 'running':
             yield dsleep(1)
             session.data['last_update'] = time.time()
@@ -233,7 +231,6 @@ class FakeDataAgent:
 
         session.data = {'requested_delay': delay,
                         'delay_so_far': 0}
-        session.set_status('running')
         t0 = time.time()
         while session.status == 'running':
             session.data['delay_so_far'] = time.time() - t0

--- a/ocs/agents/host_manager/agent.py
+++ b/ocs/agents/host_manager/agent.py
@@ -491,7 +491,6 @@ class HostManager:
         }
 
         self.running = True
-        session.set_status('running')
 
         if params['reload_config']:
             self.database = {}
@@ -613,7 +612,6 @@ class HostManager:
         """
         if not self.running:
             return False, 'Manager process is not running; params not updated.'
-        session.set_status('running')
         if params['reload_config']:
             yield self._reload_config(session)
         self._process_target_states(session, params['requests'])
@@ -621,7 +619,6 @@ class HostManager:
 
     @inlineCallbacks
     def die(self, session, params):
-        session.set_status('running')
         if not self.running:
             session.add_message('Manager process is not running.')
         else:

--- a/ocs/agents/influxdb_publisher/agent.py
+++ b/ocs/agents/influxdb_publisher/agent.py
@@ -87,7 +87,6 @@ class InfluxDBAgent:
                 This is meant only for testing. Default is False.
 
         """
-        session.set_status('starting')
         self.aggregate = True
 
         self.log.debug("Instatiating Publisher class")
@@ -100,7 +99,6 @@ class InfluxDBAgent:
                               operate_callback=lambda: self.aggregate,
                               )
 
-        session.set_status('running')
         while self.aggregate:
             time.sleep(self.loop_time)
             self.log.debug(f"Approx. queue size: {self.incoming_data.qsize()}")

--- a/ocs/agents/registry/agent.py
+++ b/ocs/agents/registry/agent.py
@@ -194,11 +194,8 @@ class Registry:
                 }
 
         """
-
-        session.set_status('starting')
         self._run = True
 
-        session.set_status('running')
         last_publish = time.time()
         while self._run:
             yield dsleep(1)

--- a/ocs/base.py
+++ b/ocs/base.py
@@ -44,9 +44,8 @@ class OpCode(Enum):
     - If the session.status == "done" then the op_code will be
       assigned a value of either SUCCEEDED or FAILED based on
       session.success.
-    - If the session.status == "running", and the session.data
-      contains a key "degraded" that evaluate to True, then the
-      op_code will be DEGRADED rather than RUNNING.
+    - If the session.status == "running", and session.degraded is
+      True, then the op_code will be DEGRADED rather than RUNNING.
 
     """
 

--- a/ocs/base.py
+++ b/ocs/base.py
@@ -38,9 +38,15 @@ TIMEOUT = ResponseCode.TIMEOUT.value
 class OpCode(Enum):
     """Enumeration of OpSession "op_code" values.
 
-    The op_code corresponds to the session.status, except that if the
-    session.status == "done" then the op_code will be assigned a value
-    of either SUCCEEDED or FAILED based on session.success.
+    The op_code corresponds to the session.status, with the following
+    extensions:
+
+    - If the session.status == "done" then the op_code will be
+      assigned a value of either SUCCEEDED or FAILED based on
+      session.success.
+    - If the session.status == "running", and the session.data
+      contains a key "degraded" that evaluate to True, then the
+      op_code will be DEGRADED rather than RUNNING.
 
     """
 
@@ -76,3 +82,10 @@ class OpCode(Enum):
     #: EXPIRED may used to mark session information as invalid in cases
     #: where the state cannot be determined.
     EXPIRED = 7
+
+    #: DEGRADED indicates that an operation meets the requirements for
+    #: state RUNNING, but is self-reporting as being in a problematic
+    #: state where it is unable to perform its primary functions (for
+    #: example, if a Process to operate some hardware is trying to
+    #: re-establish connection to that hardware).
+    DEGRADED = 8

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -1249,13 +1249,19 @@ class OpSession:
         The only valid transitions are forward in the sequence
         [starting, running, stopping, done]; i.e. it is forbidden for
         the status of an OpSession to move from stopping to running.
+
+        If this function is called from a worker thread, it will be
+        scheduled to run in the reactor, and will block until that is
+        complete.
+
         """
         if timestamp is None:
             timestamp = time.time()
         if not in_reactor_context():
-            return reactor.callFromThread(self.set_status, status,
-                                          timestamp=timestamp,
-                                          log_status=log_status)
+            return threads.blockingCallFromThread(reactor,
+                                                  self.set_status, status,
+                                                  timestamp=timestamp,
+                                                  log_status=log_status)
         # Sanity check the status value.
         from_index = SESSION_STATUS_CODES.index(self.status)  # current status valid?
         to_index = SESSION_STATUS_CODES.index(status)        # new status valid?

--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -1220,9 +1220,14 @@ class OpSession:
         """
         if self.status is None:
             return OpCode.NONE
-        elif self.status in ['starting', 'running', 'stopping']:
+        elif self.status in ['starting', 'stopping']:
             return {'starting': OpCode.STARTING, 'running': OpCode.RUNNING,
                     'stopping': OpCode.STOPPING}[self.status]
+        elif self.status == 'running':
+            if self.data.get('degraded', False):
+                return OpCode.DEGRADED
+            else:
+                return OpCode.RUNNING
         elif self.success:
             return OpCode.SUCCEEDED
         else:

--- a/tests/agents/test_fakedata.py
+++ b/tests/agents/test_fakedata.py
@@ -19,7 +19,8 @@ def test_fake_data_set_heartbeat(agent):
 
 def test_fake_data_acq(agent):
     session = create_session('acq')
-    params = {'test_mode': True}
+    params = {'test_mode': True,
+              'degradation_period': None}
     res = agent.acq(session, params=params)
     assert res[0] is True
 

--- a/tests/agents/util.py
+++ b/tests/agents/util.py
@@ -33,7 +33,7 @@ def create_agent_fixture(agent_class, agent_kwargs={}):
 def create_session(op_name):
     """Create an OpSession with a mocked app for testing."""
     mock_app = mock.MagicMock()
-    session = OpSession(1, op_name, app=mock_app)
+    session = OpSession(1, op_name, app=mock_app, status='running')
 
     return session
 


### PR DESCRIPTION
## Description

Primary changes:
- `session.op_code` enum has a new value "DEGRADED" (8), which is returned in the case that an operation is "running" but has `session.data['degraded']` exists and is True
- `session.status` will automatically be put in state "running" just before launching the agent operation code
- When running `session.set_status` from a "blocking" operation (i.e. from a worker thread), the code now blocks while waiting for the status to change (the change is made in the reactor thread).  This means that one can reasonably expect that `set_status('running')` does not return until `session.status == 'running'`.  (This is less useful, given the point above ...
- `session.publish_status` has been removed. Previously, this was called whenever `session.add_message` was called, and caused the encoded session to be pushed to `{agent_address}.feed`.  I am pretty sure that no one uses this feed.  The `Registry` uses the heartbeat to get op_code.

As a result, also:
- All agents in ocs are all updated to not call session.set_status() unnecessarily.
- OCS docs updated to not call session.set_status() unnecessarily.
- FakeDataAgent acq process has options to exercise the DEGRADED state.

The side-effects of this should be minimal.  Agents that call `session.set_status('running')`, even though it's already running, will not get an error or anything.  Agents that don't implement session.data['degraded'] don't need to worry about activating the DEGRADED op code.

## Motivation and Context

Addresses #357 and #367.

## How Has This Been Tested?

Tested extensively with FakeDataAgent.  Before removing interfaces, I checked that there are no users in ocs, socs, ocs-web.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
