### PR TITLE
Relax pinned versions on docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==4.2.0
-sphinx_rtd_theme==1.0.0
-sphinx-argparse==0.3.1
+sphinx>=5.0.0
+sphinx_rtd_theme>=2.0.0
+sphinx-argparse>=0.4.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Same fix as in https://github.com/simonsobs/socs/pull/618.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
readthedocs builds are currently broken. While readthedocs does [recommend pinning dependencies](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#use-a-requirements-file-for-python-dependencies) we haven't been good about updating them occasionally. I'd rather stay consistent with the other repos that have already implemented this same fix. We might run into some latest version breaking something in the future -- at which point I expect we'll pin again.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It'll test in the docs build for this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
