### PR TITLE
Fix bug in how args are parsed from site-config

### DIFF
--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -337,8 +337,17 @@ class ArgContainer:
 
         cur_key = '__positional__'
         self.arg_dict[cur_key] = []
+
+        def is_new_arg(arg):
+            if arg[0] != '-':
+                return False
+            # Check that first character after '-' is not a digit
+            if not arg.strip('-')[0].isalpha():
+                return False
+            return True
+
         for arg in args:
-            if arg[0] == '-':
+            if is_new_arg(arg):
                 cur_key = arg
                 self.arg_dict[cur_key] = []
             else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Small change to fix the bug kyohei found here: https://github.com/simonsobs/ocs/issues/377
Turns out the ArgContainer site-config uses to parse site-config args was treating negative numbers like new arguments, which was causing some issues.
## Description
<!--- Describe your changes in detail -->
ArgContainer now checks that the first char after leading hyphens is in the alphabet, when determining if it should create a new arg entry.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/simonsobs/ocs/issues/377

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally that new namespace looks like I'd expect
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
