### PR TITLE
Adds message_idx to OCS feeds to protect against duplicate data in the aggregator

### DIFF
--- a/ocs/agents/aggregator/drivers.py
+++ b/ocs/agents/aggregator/drivers.py
@@ -342,7 +342,7 @@ class Provider:
                 message index for the incoming data. If a message index is repeated, the data will be ignored.
         """
         if message_idx is not None:
-            if message_idx == self.last_message_idx: # Ignore duplicate messages
+            if message_idx == self.last_message_idx:  # Ignore duplicate messages
                 return
             self.last_message_idx = message_idx
 

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -242,6 +242,7 @@ class Feed:
             # Publish message immediately
             try:
                 self.agent.publish(self.address, (message, self.encoded()))
+                self.message_idx += 1
             except TransportLost:
                 self.agent.log.error('Could not publish to Feed. TransportLost. '
                                      + 'crossbar server likely unreachable.')

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -102,6 +102,7 @@ class Feed:
         self.feed_name = feed_name
         self.record = record
         self.agg_params = agg_params
+        self.message_idx = 0
 
         self.buffer_time = buffer_time
         self.buffer_start_time = None
@@ -119,7 +120,8 @@ class Feed:
             "address": self.address,
             "record": self.record,
             "session_id": self.agent.agent_session_id,
-            "agent_class": self.agent.class_name
+            "agent_class": self.agent.class_name,
+            'message_idx': self.message_idx,
         }
 
     def flush_buffer(self):
@@ -136,6 +138,7 @@ class Feed:
                     {k: b.encoded() for k, b in self.blocks.items() if b.timestamps},
                     self.encoded()
                 ))
+                self.message_idx += 1
             except TransportLost:
                 self.agent.log.error('Could not publish to Feed. TransportLost. '
                                      + 'crossbar server likely unreachable.')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the field `message_idx` to the OCSFeed object, which is included in the encoded feed data sent with each message. This is incremented every time a message is sent, and is checked in the aggregator agent to prevent saving duplicate data packets, which we've seen a number of times (f[or instance here](https://github.com/simonsobs/daq-discussions/discussions/100))

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This should solve issues we've seen with duplicate samples in the aggregator, as is seen here: https://github.com/simonsobs/daq-discussions/discussions/100

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has not yet been tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
