### PR TITLE
Pin numpy<2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,8 @@ setproctitle
 influxdb
 
 # FakeDataAgent
-numpy
+# 2.0 pin required until https://github.com/simonsobs/so3g/issues/184 is fixed
+numpy<2.0
 
 # Documentation generation
 # see docs/requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(name='ocs',
           'deprecation',
           'PyYAML',
           'influxdb',
-          'numpy',
+          'numpy<2.0',  # pin until 2.0 is supported in so3g
           'importlib_metadata;python_version<"3.10"',
           'setproctitle',
       ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pins numpy<2.0. This will be needed until https://github.com/simonsobs/so3g/issues/184 is resolved.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tests start to segfault if numpy>=2.0 is used:
```
$ python3 -m pytest --cov --cov-report html
================================================= test session starts =================================================
platform linux -- Python 3.11.9, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/koopman/git/ocs/tests
configfile: pytest.ini
plugins: docker-3.1.1, cov-5.0.0, twisted-1.14.2
collected 163 items

agents/test_aggregator_agent.py ......                                                                          [  3%]
agents/test_fakedata.py .......                                                                                 [  7%]
agents/test_host_manager.py .                                                                                   [  8%]
agents/test_influxdb_publisher_agent.py ......                                                                  [ 12%]
agents/test_influxdb_publisher_drivers.py ....                                                                  [ 14%]
agents/test_ocs_plugin_standard.py .                                                                            [ 15%]
agents/test_registry_agent.py ......                                                                            [ 19%]
integration/test_aggregator_agent_integration.py .                                                              [ 19%]
integration/test_crossbar_integration.py .Fatal Python error: Segmentation fault

Current thread 0x00007acf1abc8b80 (most recent call first):
  File "/home/koopman/git/ocs/.venv/lib/python3.11/site-packages/so3g/hk/getdata.py", line 153 in _get_groups
  File "/home/koopman/git/ocs/.venv/lib/python3.11/site-packages/so3g/hk/getdata.py", line 208 in get_fields
  File "/home/koopman/git/ocs/tests/integration/test_crossbar_integration.py", line 138 in test_aggregator_after_crossbar_restart
  File "/home/koopman/git/ocs/.venv/lib/python3.11/site-packages/pytest_twisted.py", line 422 in _async_pytest_pyfunc_call
  File "/home/koopman/git/ocs/.venv/lib/python3.11/site-packages/twisted/internet/defer.py", line 2003 in _inlineCallbacks
  File "/home/koopman/git/ocs/.venv/lib/python3.11/site-packages/twisted/internet/defer.py", line 2172 in _cancellableInlineCallbacks
  File "/home/koopman/git/ocs/.venv/lib/python3.11/site-packages/twisted/internet/defer.py", line 2260 in unwindGenerator
  File "/home/koopman/git/ocs/.venv/lib/python3.11/site-packages/twisted/internet/defer.py", line 212 in maybeDeferred
  File "/home/koopman/git/ocs/.venv/lib/python3.11/site-packages/pytest_twisted.py", line 362 in in_reactor
  File "/home/koopman/git/ocs/.venv/lib/python3.11/site-packages/twisted/internet/base.py", line 1090 in runUntilCurrent
  File "/home/koopman/git/ocs/.venv/lib/python3.11/site-packages/twisted/internet/base.py", line 705 in mainLoop
  File "/home/koopman/git/ocs/.venv/lib/python3.11/site-packages/twisted/internet/base.py", line 695 in run

Extension modules: greenlet._greenlet, zope.interface._zope_interface_coptimizations, yaml._yaml, _cffi_backend, numpy._core._multiarray_umath, numpy._core._multiarray_tests, numpy.linalg._umath_linalg, erfa.ufunc, astropy.time._parse_times, astropy.table._column_mixins, astropy.table._np_utils, astropy.io.ascii.cparser, astropy.utils.xml._iterparser, astropy.io.fits._utils, astropy.io.fits.hdu.compressed._compression, astropy.io.votable.tablewriter, astropy.wcs._wcs, ephem._libastro, setproctitle._setproctitle, msgpack._cmsgpack, charset_normalizer.md, requests.packages.charset_normalizer.md, requests.packages.chardet.md, numpy.random._common, numpy.random.bit_generator, numpy.random._bounded_integers, numpy.random._mt19937, numpy.random.mtrand, numpy.random._philox, numpy.random._pcg64, numpy.random._sfc64, numpy.random._generator (total: 32)
zsh: segmentation fault (core dumped)  python3 -m pytest --cov --cov-report html
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran tests locally, this fixes the segfault shown above.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
