### PR TITLE
Remove old compiled spt3g/so3g layers from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN python -m pip install -r requirements.txt
 COPY . /app/ocs/
 
 # Install ocs
-RUN python3 -m pip install .
+RUN python -m pip install .
 
 # Reset workdir to avoid local imports
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install -y \
 # Setup virtualenv
 RUN python -m virtualenv /opt/venv/
 ENV PATH="/opt/venv/bin:$PATH"
+RUN python -m pip install -U pip
 
 # Install init system
 RUN python -m pip install dumb-init

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,16 @@ RUN apt-get update && apt-get install -y \
     git \
     python3 \
     python3-pip \
+    python3-virtualenv \
     python-is-python3 \
     vim
 
+# Setup virtualenv
+RUN python -m virtualenv /opt/venv/
+ENV PATH="/opt/venv/bin:$PATH"
+
 # Install init system
-RUN pip3 install dumb-init
+RUN python -m pip install dumb-init
 
 # Copy in and install requirements
 # This will leverage the cache for rebuilds when modifying OCS, avoiding
@@ -42,13 +47,13 @@ RUN pip3 install dumb-init
 COPY requirements/ /app/ocs/requirements
 COPY requirements.txt /app/ocs/requirements.txt
 WORKDIR /app/ocs/
-RUN pip3 install -r requirements.txt
+RUN python -m pip install -r requirements.txt
 
 # Copy the current directory contents into the container at /app
 COPY . /app/ocs/
 
 # Install ocs
-RUN pip3 install .
+RUN python3 -m pip install .
 
 # Reset workdir to avoid local imports
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@
 # A container setup with an installation of ocs.
 
 # Use ubuntu base image
-FROM simonsobs/so3g:v0.1.3-13-g5471f0d
+FROM ubuntu:22.04
+
+# Set timezone to UTC
+ENV TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Set locale
 ENV LANG C.UTF-8
@@ -22,8 +26,11 @@ ENV OCS_CONFIG_DIR=/config
 ENV PYTHONUNBUFFERED=1
 
 # Install python and pip
-RUN apt-get update && apt-get install -y python3 \
+RUN apt-get update && apt-get install -y \
+    git \
+    python3 \
     python3-pip \
+    python-is-python3 \
     vim
 
 # Install init system

--- a/docs/developer/docker.rst
+++ b/docs/developer/docker.rst
@@ -26,6 +26,12 @@ OCS Agent via ``ocs-agent-cli``. See the `Dockerfile reference
 <https://docs.docker.com/engine/reference/builder/>`_ in the Docker
 documentation for more information about how to write a Dockerfile.
 
+.. note::
+
+    ``ocs`` and its dependencies are installed into a ``virutualenv`` kept in
+    ``/opt/venv/``. This is enabled by putting ``/opt/venv/bin/`` at the front of
+    the PATH. This is in place to isolate the installation from the system Python.
+
 Building Upon the Base Image
 ----------------------------
 
@@ -43,19 +49,18 @@ that looks something like:
 
     # Install required dependencies
     RUN apt-get update && apt-get install -y rsync \
-        wget \
-        python3-pip
+        wget
 
     # Copy in and install requirements
     COPY requirements.txt /app/my-ocs-agent/requirements.txt
     WORKDIR /app/my-ocs-agent/
-    RUN pip3 install -r requirements.txt
+    RUN python -m pip install -r requirements.txt
 
     # Copy the current directory contents into the container at /app
     COPY . /app/my-ocs-agent/
 
     # Install my-ocs-agent
-    RUN pip3 install .
+    RUN python -m pip install .
 
     # Run agent on container startup
     ENTRYPOINT ["dumb-init", "ocs-agent-cli"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR rebases the ocs Docker image onto the `ubuntu:22.04` base image. It also sets up and enables a Python `virualenv` for the `ocs` installation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This has been long overdue, but historically we built upon the [simonsobs/so3g](https://hub.docker.com/r/simonsobs/so3g) image, which is built upon the [simonsobs/spt3g](https://hub.docker.com/r/simonsobs/spt3g) image, which in turn was built upon `ubuntu:22.04`.

This chain of images was to facilitate installation of the spt3g/so3g stack, which prior to so3g becoming pip installable needed to be compiled. Each layer compiled its respective package. Now that we can (and do) install so3g from pip, and so3g brings its own spt3g with it, we don't need these base layers.

There were a few issues with this historical stack still being in place, the largest of which is that somehow in the build process Python 3.10 was being replaced with Python 3.8. (3.10 is present in `simonsobs/so3g`, but only 3.8 is present in `simonsobs/ocs`.) This may have exacerbated the setuptools issue in #391.

This also saves a bunch of disk space, since we don't have everything needed to compile spt3g/so3g in the image anymore. Compare these two builds to see it's about 1.2GB!
```
REPOSITORY        TAG                  IMAGE ID       CREATED              SIZE
ocs               main                 6885fb6b5fe3   About a minute ago   2.67GB
ocs               rework               96e71b04582c   About a minute ago   1.46GB
```

The `virtualenv` setup also prepares us for the update to `ubuntu:24.04`, which comes with Python 3.12 which enforces uses of virtual environments.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Builds and tests have been run locally and all pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
