### PR TITLE
Replace deprecated `threading.currentThread`

### DIFF
--- a/ocs/ocs_twisted.py
+++ b/ocs/ocs_twisted.py
@@ -126,13 +126,13 @@ def in_reactor_context():
     it's the main thread.  Will raise RuntimeError if the thread name
     is confusing.
     """
-    t = threading.currentThread()
+    t = threading.current_thread()
     if 'PoolThread' in t.name:
         return False
     if 'MainThread' in t.name:
         return True
     raise RuntimeError('Could not determine threading context: '
-                       'currentThread.name="%s"' % t.name)
+                       'current_thread.name="%s"' % t.name)
 
 
 class Pacemaker:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
See deprecation note in the threading docs: https://docs.python.org/3/library/threading.html#threading.current_thread

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This shows up when running tests:
```
  /home/koopman/git/ocs/ocs/ocs_twisted.py:129: DeprecationWarning: currentThread() is deprecated, use current_thread() instead
    t = threading.currentThread()
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tests run locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
