### PR TITLE
Adds kill_on_exit to _AgentRunner in testing

### DIFF
--- a/ocs/testing.py
+++ b/ocs/testing.py
@@ -23,8 +23,8 @@ class _AgentRunner:
             i.e. '../agents/fake_data/fake_data_agent.py'
         agent_name (str): Short, unique name for the agent
         args (list): Additional CLI arguments to add when starting the Agent
-        kill_to_exit (bool): If True, will send a kill signal to exit instead of 
-            interrupt.
+        kill_to_exit (bool): If True, will send a kill signal to exit instead
+            of interrupt.
 
     """
 
@@ -119,7 +119,7 @@ class _AgentRunner:
             raise RuntimeError('Agent timed out.')
 
 
-def create_agent_runner_fixture(agent_path, agent_name, args=None, timeout=60):
+def create_agent_runner_fixture(agent_path, agent_name, args=None, timeout=60, kill_to_exit=False):
     """Create a pytest fixture for running a given OCS Agent.
 
     Parameters:
@@ -131,11 +131,13 @@ def create_agent_runner_fixture(agent_path, agent_name, args=None, timeout=60):
             be interrupted. This typically indicates a crash within the agent.
             This timeout should be longer than you expect the agent to run for
             during a given test. Defaults to 60 seconds.
+        kill_to_exit (bool): If True, will send a kill signal to exit instead of
+            interrupt.
 
     """
     @pytest.fixture()
     def run_agent(cov):
-        runner = _AgentRunner(agent_path, agent_name, args)
+        runner = _AgentRunner(agent_path, agent_name, args, kill_to_exit=kill_to_exit)
         runner.run(timeout=timeout)
 
         yield


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the option to kill agents in tests using SIGKILL instead of SIGINT.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In my development of of the HWP emulator-based integration tests (https://github.com/simonsobs/socs/pull/802) I'm finding that, though the test are working, shutting agents down with a single interrupt command sometimes does not work, and is fairly slow (~10 sec per agent for the agents that do work). I _believe_ this could be something related how and when socket connections are closed by the emulator but I'm not entirely sure.

I have found that using a SIGKILL instead of SIGINT to shutdown agents is much faster and more reliable, and I don't really think we care about clean shutdowns at the end of states, so I think this is a good option for some tests, such as the HWP integration tests which use many different agents.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested by running HWP integration tests from the PR above locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
