### PR TITLE
Safely stop agent heartbeat and handle Disconnected exception

### DIFF
--- a/ocs/ocs_agent.py
+++ b/ocs/ocs_agent.py
@@ -265,7 +265,11 @@ class OCSAgent(ApplicationSession):
     def onLeave(self, details):
         self.log.info('session left: {}'.format(details))
         if self.heartbeat_call is not None:
-            self.heartbeat_call.stop()
+            self.log.info('stopping heartbeat')
+            if self.heartbeat_call.running:
+                self.heartbeat_call.stop()
+            else:
+                self.log.warn('heartbeat was not running')
 
         # Normal shutdown
         if details.reason == "wamp.close.normal":

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -1,6 +1,7 @@
 from ocs.ocs_agent import in_reactor_context
 from twisted.internet import reactor
-from autobahn.wamp.exception import Disconnected, TransportLost
+from autobahn.exception import Disconnected
+from autobahn.wamp.exception import TransportLost
 import time
 import re
 

--- a/ocs/ocs_feed.py
+++ b/ocs/ocs_feed.py
@@ -1,6 +1,6 @@
 from ocs.ocs_agent import in_reactor_context
 from twisted.internet import reactor
-from autobahn.wamp.exception import TransportLost
+from autobahn.wamp.exception import Disconnected, TransportLost
 import time
 import re
 
@@ -136,8 +136,8 @@ class Feed:
                     {k: b.encoded() for k, b in self.blocks.items() if b.timestamps},
                     self.encoded()
                 ))
-            except TransportLost:
-                self.agent.log.error('Could not publish to Feed. TransportLost. '
+            except (Disconnected, TransportLost):
+                self.agent.log.error('Could not publish to Feed. '
                                      + 'crossbar server likely unreachable.')
             for k, b in self.blocks.items():
                 b.clear()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a check to make sure the heartbeat is still running before trying to stop the looping call, `self.heartbeat_call`. We also add exception handling for the `autobahn.exception.Disconnected` exception we've been seeing occasionally when an agent loses its connection to the crossbar server and goes to flush its feed buffer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If an agent loses its connection to the crossbar server the heartbeat looping call might crash before [it is stopped](https://github.com/simonsobs/ocs/blob/d729e0493e7ee87a4456136c6fdfe0e9b31871e4/ocs/ocs_agent.py#L268) when `onLeave()` is triggered. This hits an assertion error in twisted.

Additionally, when the agent goes to flush its buffer by publishing any data it has that publish call will fail with an `autobahn.exception.Disconnected` exception. We were already handling the `TransportLost` exception, so we just add `Disconnected`.

An example of hitting both of these at the same time can be see in #417.

Resolves #417.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I haven't been able to reproduce #417 locally. I've tried by running a small ocs network with the registry and several fake data agents. I then cycle the crossbar server over and over again, hoping to hit the exception just right. Cycling a couple dozen times never hit it.

I'm still going to try to think of a way to reproduce this, but wanted to get the PR open.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
