### PR TITLE
Remove long deprecated `client_t.run_control_script2`

### DIFF
--- a/docs/developer/site_config.rst
+++ b/docs/developer/site_config.rst
@@ -169,36 +169,3 @@ additional site-info settable from the site's parser.
 .. note::
     For examples calling these commandline arguments see
     :ref:`ocs_agent_cmdline_examples`.
-
-
-Control Clients and the Site Config
-===================================
-
-As of this writing, Control Clients do not store configuration in the
-SCF.  But there is an interim interface available for Control Clients
-to access the Site Configuration, with the usual command-line
-overrides.  Control Clients that use the ``run_control_script``
-function to launch can instead use ``run_control_script2``, which
-behaves as follows:
-
-.. autofunction:: ocs.client_t.run_control_script2
-    :noindex:
-
-The control client script might look something like this (see also
-river_ctrl.py in the examples):
-
-.. code-block:: python
-
-  def my_script(app, pargs):
-      from ocs import client_t
-
-      # We've added a --target option.
-      # Construct the full agent address.
-      agent_addr = '%s.%s' % (pargs.address_root, pargs.target)
-
-      # Create a ProcessClient for the process 'acq'.
-      cw = client_t.ProcessClient(app, agent_addr, 'acq')
-
-      print('Starting a data acquisition process...')
-      d1 = yield cw.start()
-      #...

--- a/example/nonblocking_ops/example_ctrl.py
+++ b/example/nonblocking_ops/example_ctrl.py
@@ -34,4 +34,4 @@ if __name__ == '__main__':
     # We don't pass a parser in, so it will be auto-generated and
     # populated from the command line.  We hard-code our one argument,
     # the target agent instance_id.
-    client_t.run_control_script2(my_script, target='example1')
+    client_t.run_control_script(my_script, target='example1')

--- a/ocs/client_t.py
+++ b/ocs/client_t.py
@@ -9,15 +9,6 @@ from twisted.internet.error import ReactorNotRunning
 
 from autobahn.wamp.types import ComponentConfig
 from autobahn.twisted.wamp import ApplicationSession, ApplicationRunner
-import deprecation
-
-
-@deprecation.deprecated(
-    deprecated_in='v0.6.1',
-    details="Renamed to run_control_script"
-)
-def run_control_script2(*args, **kwargs):
-    run_control_script(*args, **kwargs)
 
 
 def run_control_script(function, parser=None, *args, **kwargs):
@@ -53,7 +44,7 @@ def run_control_script(function, parser=None, *args, **kwargs):
         from ocs import client_t, site_config
         parser = site_control.add_arguments()  # initialized ArgParser
         parser.add_option('--target')          # Options for this client
-        client_t.run_control_script2(my_script, parser=parser)
+        client_t.run_control_script(my_script, parser=parser)
 
     In the my_script function, use parser_args.target to get the
     target.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes `client_t.run_control_script2`, which we deprecated a little over 4 years ago now.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We haven't really used the client interface provided by `client_t` ever since `matched_client`/`ocs_client` was introduced.

Also, with the removal of the old plugin system in #407, I'd like the next release of ocs to include some clean up and remove interfaces we've had deprecated for a while. Be on the look out for similar PRs for other deprecated components soon.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Hasn't really been tested. I tried running the miniobs example, but ran into some issues before even getting to the `run_control_script` part...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
