### PR TITLE
Remove `site_config.reparse_args`

### DIFF
--- a/docs/developer/site_config.rst
+++ b/docs/developer/site_config.rst
@@ -158,14 +158,5 @@ additional site-info settable from the site's parser.
     :prog:
 
 .. note::
-    This is slightly different from the older way of parsing arguments with
-    ``reparse_args``, but should return the same namespace. The only difference is that
-    the new version parses all arguments with the argparse parser, so you can be sure
-    that defaults and type specifications will apply.
-
-    To change to the newer version, just make sure you define the agent parser
-    first, and pass it to the parse_args function as shown in the example above.
-
-.. note::
     For examples calling these commandline arguments see
     :ref:`ocs_agent_cmdline_examples`.

--- a/ocs/client_t.py
+++ b/ocs/client_t.py
@@ -1,3 +1,5 @@
+import argparse
+
 import ocs
 
 import txaio
@@ -50,9 +52,8 @@ def run_control_script(function, parser=None, *args, **kwargs):
     target.
     """
     if parser is None:
-        parser = ocs.site_config.add_arguments()
-    pargs = parser.parse_args()
-    ocs.site_config.reparse_args(pargs, '*control*')
+        parser = argparse.ArgumentParser()
+    pargs = ocs.site_config.parse_args(agent_class='*control*', parser=parser)
     server, realm = pargs.site_hub, pargs.site_realm
     session = ControlClientSession(ComponentConfig(realm, {}), function,
                                    [pargs] + list(args), kwargs)

--- a/ocs/site_config.py
+++ b/ocs/site_config.py
@@ -7,7 +7,6 @@ import sys
 import yaml
 import argparse
 import collections
-import deprecation
 
 
 class SiteConfig:
@@ -579,45 +578,6 @@ def add_site_attributes(args, site, host=None):
         args.log_dir = host.log_dir
     if (args.crossbar_timeout is None) and (host is not None):
         args.crossbar_timeout = host.crossbar_timeout
-
-
-@deprecation.deprecated(deprecated_in='v0.6.0',
-                        details="Use site_config.parse_args instead")
-def reparse_args(args, agent_class=None):
-    """
-    THIS FUNCTION IS NOW DEPRECATED... Use the parse_args function instead
-    to parse command line and site-config args simultaneously.
-
-    Process the site-config arguments, and modify them in place
-    according to the agent-instance's computed instance-id.
-
-    Args:
-        args: The argument object returned by
-            ArgumentParser.parse_args(), or equivalent.
-
-        agent_class: Class name passed in to match against the list of
-            device classes in each host's list.
-
-    Special values accepted for agent_class:
-    - '*control*': do not insist on matching host or device.
-    """
-    if args.site == 'none':
-        return args
-
-    site, host, instance = get_config(args, agent_class=agent_class)
-
-    add_site_attributes(args, site, host=host)
-
-    if instance is not None:
-        if args.instance_id is None:
-            args.instance_id = instance.data['instance-id']
-
-        for k, v in instance.data['arguments']:
-            kprop = k.lstrip('-').replace('-', '_')
-            print('site_config is setting values of "%s" to "%s".' % (kprop, v))
-            setattr(args, kprop, v)
-
-    return args
 
 
 def get_control_client(instance_id, site=None, args=None, start=True,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the `site_config.reparse_args()` function. There was still one lingering use in `client_t.run_control_script`, so we remove that here as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This has been deprecated since [v0.6.0](https://github.com/simonsobs/ocs/releases/tag/v0.6.0), back in March 2020. This is a part of some code clean up efforts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I still need to test this, specifically the `client_t.run_control_script` change. Draft until then, though comments welcome.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
