### PR TITLE
Unpin numpy and add 3.12 to supported versions list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "deprecation",
     "importlib_metadata;python_version<\"3.10\"",
     "influxdb",
-    "numpy<2.0",  # pin until 2.0 is supported in so3g
+    "numpy",
     "PyYAML",
     "setproctitle",
     "twisted",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dependencies = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ setproctitle
 influxdb
 
 # FakeDataAgent
-# 2.0 pin required until https://github.com/simonsobs/so3g/issues/184 is fixed
-numpy<2.0
+numpy
 
 # Documentation generation
 # see docs/requirements.txt


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This removes the pin on numpy, and updates the list of supported Python versions to include 3.12.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This should be fine now that so3g supports numpy 2 [1].

[1] - https://github.com/simonsobs/so3g/releases/tag/v0.2.0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Installed and ran ocs tests on Python 3.12.9 locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
