### PR TITLE
Add ability to pass credentials to InfluxDB publisher client

### DIFF
--- a/docs/agents/influxdb_publisher.rst
+++ b/docs/agents/influxdb_publisher.rst
@@ -46,8 +46,39 @@ Add the InfluxDB Publisher Agent container to your docker compose file::
     hostname: ocs-docker
     environment:
       - INSTANCE_ID=influxagent
+      - INFLUXDB_USERNAME=admin       # optional
+      - INFLUXDB_PASSWORD=password    # optional
     volumes:
       - ${OCS_CONFIG_DIR}:/config:ro
+
+By default, InfluxDB HTTP authentication is not required. However, if needed,
+you can optionally pass credentials to use when connecting to your InfluxDB
+instance through the environment variables shown above or through a file, for
+instance if you would like to use Docker Secrets. A Docker Secrets example is
+shown below::
+
+  secrets:
+    INFLUXDB_USERNAME:
+      file: ${PWD}/secrets/INFLUXDB_USERNAME
+    INFLUXDB_PASSWORD:
+      file: ${PWD}/secrets/INFLUXDB_PASSWORD
+  services:
+    ocs-influxdb-publisher:
+      image: simonsobs/ocs:latest
+      hostname: ocs-docker
+      secrets:
+        - INFLUXDB_USERNAME
+        - INFLUXDB_PASSWORD
+      environment:
+        - INSTANCE_ID=influxagent
+        - INFLUXDB_USERNAME_FILE=/run/secrets/INFLUXDB_USERNAME
+        - INFLUXDB_PASSWORD_FILE=/run/secrets/INFLUXDB_PASSWORD
+      volumes:
+        - ${OCS_CONFIG_DIR}:/config:ro
+
+.. note::
+    The ``INFLUXDB_USERNAME`` and ``INFLUXDB_PASSWORD`` variables will take
+    precedence if they are also present when using the ``_FILE`` variables.
 
 You will also need an instance of InfluxDB running somewhere on your network.
 This likely should go in a separate docker compose file so that it remains

--- a/tests/test_influxdb_publisher.py
+++ b/tests/test_influxdb_publisher.py
@@ -1,6 +1,8 @@
+import os
+
 import pytest
 
-from ocs.agents.influxdb_publisher.drivers import Publisher, timestamp2influxtime
+from ocs.agents.influxdb_publisher.drivers import Publisher, timestamp2influxtime, _get_credentials
 
 
 @pytest.mark.parametrize("t,protocol,expected",
@@ -27,3 +29,32 @@ def test_format_data():
 
     expected = 'test_address,feed=test_feed key1=1i,key2=2.3,key3="test" 1615394417359038720'
     assert Publisher.format_data(data, feed, 'line')[0] == expected
+
+
+def test__get_credentials(tmp_path):
+    # Defaults
+    assert _get_credentials() == ('root', 'root')
+
+    # Set from file
+    d = tmp_path
+    username_file = d / "username"
+    username_file.write_text("admin", encoding="utf-8")
+    password_file = d / "password"
+    password_file.write_text("testpass", encoding="utf-8")
+
+    os.environ['INFLUXDB_USERNAME_FILE'] = str(username_file)
+    os.environ['INFLUXDB_PASSWORD_FILE'] = str(password_file)
+    assert _get_credentials() == ('admin', 'testpass')
+
+    # Set from env var
+    os.environ['INFLUXDB_USERNAME'] = 'user_var'
+    os.environ['INFLUXDB_PASSWORD'] = 'pass_var'
+    assert _get_credentials() == ('user_var', 'pass_var')
+
+    # Cleanup
+    vars_ = ['INFLUXDB_USERNAME_FILE',
+             'INFLUXDB_PASSWORD_FILE',
+             'INFLUXDB_USERNAME',
+             'INFLUXDB_PASSWORD']
+    for v in vars_:
+        os.environ.pop(v)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds two methods for passing credentials to the `InfluxDBClient` within the InfluxDB publisher agent.

Credentials can be passed either directly through `INFLUXDB_USERNAME` and `INFLUXDB_PASSWORD`, or by reading files specified with `INFLUXDB_USERNAME_FILE` and `INFLUXDB_PASSWORD_FILE`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #431.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
There's a new unit test for testing loading credentials via the various methods. I also tested this locally with an instance of InfluxDB 1.8.10 where I created a username/password, then enabled HTTP auth via setting `INFLUXDB_HTTP_AUTH_ENABLED=true` in the compose file, like this:

```
  influxdb:
    image: "influxdb:1.8"
    container_name: "influxdb"
    volumes:
      - influxdb-storage:/var/lib/influxdb
    environment:
      - INFLUXDB_HTTP_AUTH_ENABLED=true
```

Then I tested passing no credentials (defaults to 'root'/'root'), which fails. I tested passing credentials from file via Docker Secrets. And then tested passing credentials via the environment variables directly, also testing that this takes precedence over reading from file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
