### PR TITLE
InfluxDB Publisher v1: Add support for HTTPS connection

### DIFF
--- a/docs/agents/influxdb_publisher.rst
+++ b/docs/agents/influxdb_publisher.rst
@@ -34,6 +34,8 @@ Add an InfluxDBAgent to your OCS configuration file::
                      '--port', 8086,
                      '--protocol', 'line',
                      '--gzip', True,
+                     '--ssl', False,
+                     '--verify-ssl', False,
                      '--database', 'ocs_feeds']},
 
 Docker Compose

--- a/ocs/agents/influxdb_publisher/agent.py
+++ b/ocs/agents/influxdb_publisher/agent.py
@@ -95,6 +95,8 @@ class InfluxDBAgent:
                               self.incoming_data,
                               port=self.args.port,
                               protocol=self.args.protocol,
+                              ssl=self.args.ssl,
+                              verify_ssl=self.args.verify_ssl,
                               gzip=self.args.gzip,
                               operate_callback=lambda: self.aggregate,
                               )
@@ -145,6 +147,14 @@ def make_parser(parser=None):
                         choices=['json', 'line'],
                         help="Protocol for writing data. Either 'line' or "
                              "'json'.")
+    pgroup.add_argument('--ssl',
+                        type=bool,
+                        default=False,
+                        help="Use https instead of http to connect to InfluxDB, defaults to False.")
+    pgroup.add_argument('--verify-ssl',
+                        type=bool,
+                        default=False,
+                        help="Verify SSL certificates for HTTPS requests, defaults to False.")
     pgroup.add_argument('--gzip',
                         type=bool,
                         default=False,

--- a/ocs/agents/influxdb_publisher/drivers.py
+++ b/ocs/agents/influxdb_publisher/drivers.py
@@ -60,6 +60,8 @@ class _InfluxDBClientArgs:
     port: int
     username: str
     password: str
+    ssl: bool
+    verify_ssl: bool
     gzip: bool
 
 
@@ -81,6 +83,10 @@ class Publisher:
             port for InfluxDB instance, defaults to 8086.
         protocol (str, optional):
             Protocol for writing data. Either 'line' or 'json'.
+        ssl (bool, optional):
+            Use https instead of http to connect to InfluxDB, defaults to False.
+        verify_ssl (bool, optional):
+            Verify SSL certificates for HTTPS requests, defaults to False.
         gzip (bool, optional):
             compress influxdb requsts with gzip
         operate_callback (callable, optional):
@@ -101,8 +107,16 @@ class Publisher:
 
     """
 
-    def __init__(self, host, database, incoming_data, port=8086, protocol='line',
-                 gzip=False, operate_callback=None):
+    def __init__(self,
+                 host,
+                 database,
+                 incoming_data,
+                 port=8086,
+                 protocol='line',
+                 ssl=False,
+                 verify_ssl=False,
+                 gzip=False,
+                 operate_callback=None):
         self.db = database
         self.incoming_data = incoming_data
         self.protocol = protocol
@@ -117,6 +131,8 @@ class Publisher:
             port=port,
             username=username,
             password=password,
+            ssl=ssl,
+            verify_ssl=verify_ssl,
             gzip=gzip)
         self.client = InfluxDBClient(**asdict(self.client_args))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds support for connecting to InfluxDB over HTTPS, adding the ability to set the `ssl` and `verify_ssl` arguments, which get passed to the `InfluxDBClient` object.

It also passes these new arguments (and the new credentials implemented in #431) to the client object whenever the connection is lost and the agent tries to reconnect.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
SSL support was requested in https://github.com/simonsobs/ocs/discussions/430#discussioncomment-13940541.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I have not tested SSL support, but have tested with the default `False` arguments, and HTTP connections continue to work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
