### PR TITLE
Add --json output switch for ocs-client-cli listen mode

### DIFF
--- a/ocs/client_cli.py
+++ b/ocs/client_cli.py
@@ -68,8 +68,7 @@ def get_parser():
 
     # scan
     p = client_sp.add_parser('listen', help="Subscribe to feed(s) and dump to stdout.")
-    p.add_argument('--json', action='store_true', help=
-                   "Format output as json, for consumption by jq.")
+    p.add_argument('--json', action='store_true', help="Format output as json, for consumption by jq.")
     p.add_argument('feed_selector', help="Feed name, which can include wildcard matching (double "
                    " ..).  E.g., try 'observatory..feeds.heartbeat'")
 


### PR DESCRIPTION
## Description

This helps to examine data from feeds, using cli tools.  Passing --json to `ocs-agent-cli listen` will produce output that is json.

As written the output can be piped directly into [jq](https://jqlang.org/) tool, for example.

## Motivation and Context

The ACU has a lot of high rate data fields and this makes debugging more manageable.

## How Has This Been Tested?

Tested with simulator and at site.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
