### PR TITLE
docs: Update guidance on running tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,13 +115,6 @@ Then the tests for OCS can be run using pytest, and should be run from the
   $ cd tests/
   $ python3 -m pytest
 
-To run the tests within a Docker container (useful if your local environment is
-missing some dependencies), first make sure you build the latest ocs image,
-then use docker run::
-
-  $ docker build -t ocs .
-  $ docker run --rm -w="/app/ocs/tests/" ocs sh -c "python3 -m pytest -m 'not integtest'"
-
 For more details see `tests/README.rst <tests_>`_.
 
 .. _tests: https://github.com/simonsobs/ocs/blob/main/tests/README.rst

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -36,12 +36,6 @@ unit tests run::
 This ``-m 'not integtest'`` argument skips all tests marked as integration
 tests, leaving just the unit tests.
 
-    *Note:* Unit tests can be run within a Docker container to avoid the
-    spt3g/so3g dependencies on the host system. Ensure the ocs Docker image is
-    built with your changes, then run::
-
-        $ docker run --rm -w="/app/ocs/tests/" ocs sh -c "python3 -m pytest -m 'not integtest'"
-
 Integration Tests
 -----------------
 These tests are built to test the running OCS system, and as such need several


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This update highlights the need for Docker and Docker Compose, as well as the need to build the Docker images, when running the tests.

This also drops the guidelines on running tests within containers, which was only really useful back when so3g/spt3g was difficult to install. Leaving this in is just potentially confusing to users.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Recent new users have pointed out that the tests do not run when strictly following the current instructions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested the updated procedure by strictly following the README in a clean Ubuntu 22.04 VM.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
