### PR TITLE
ocs-local-support: Add better error when hostmanager not declared

### DIFF
--- a/ocs/ocsbow.py
+++ b/ocs/ocsbow.py
@@ -1119,6 +1119,10 @@ def main_local(args=None):
 
             if any([soln == 'agent' for soln, text in supports.analysis]):
                 print('Trying to launch hostmanager agent...')
+                if not supports.host_manager['configured']:
+                    raise OcsbowError(
+                        'No HostManager configuration was found for this host. '
+                        'Check your site config (host="%s").' % supports.site_config.host.name)
                 hm = supports.host_manager['ctrl']
                 ok, message = hm.start(foreground=args.foreground)
                 if not ok:


### PR DESCRIPTION
## Description

When running "ocs-local-support agent up" to launch a hostmanager, this will raise informative message.
```
ocs.ocsbow.OcsbowError: No HostManager configuration was found for this host. Check your site config (host="localhost").
```

## Motivation and Context

Without this, the error is confusing.

## How Has This Been Tested?

This is an old patch, but just rebased and tested on modern test system and it (a) is confusing when this patch is not in place and (b) the patch works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
