### PR TITLE
Replace cancel-workflow-action with concurrency

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,6 +11,7 @@ on:
       - '.readthedocs.yaml'
   workflow_call:
 
+# Cancel workflow runs if a new commit is pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,6 +11,10 @@ on:
       - '.readthedocs.yaml'
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-test:
     name: Run unit tests
@@ -20,11 +24,6 @@ jobs:
         python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.13.1
-      with:
-        access_token: ${{ github.token }}
-
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v6
       with:
@@ -55,11 +54,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.13.1
-      with:
-        access_token: ${{ github.token }}
-
     # Run on a single version, since these tests are run in Docker
     - name: Set up Python 3.12
       uses: actions/setup-python@v6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This removes the [styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action) reusable action with the native concurrency feature of workflows. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #356.

This is just the first example in https://github.com/styfle/cancel-workflow-action, which should be the same behavior we're getting out of the reusable action right now.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has not been tested. I might just push some extra commit to this branch to see the workflow cancel here.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Repository management (change unrelated to the main code base)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
