### PR TITLE
Remove deprecated dependabot reviewers config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Cover dependabot generated PRs
+.github/** @BrianJKoopman
+/docker/crossbar/Dockerfile @BrianJKoopman

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,8 @@ updates:
     directory: "/docker/crossbar/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "BrianJKoopman"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "BrianJKoopman"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR replaces the old dependabot reviewers config with the `CODEOWNERS` file.

We haven't been using the `CODEOWNERS` file in this repo yet, but this just focuses on the files that the old config should have been covering.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The old config doesn't work and [is recommended](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/) to be replaced by the `CODEOWNERS` file.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not tested. The next time dependabot opens a PR will be the test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
